### PR TITLE
chore: simplify CI wait command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
 4. Create a PR: `gh pr create --repo cuioss/cui-test-mockwebserver-junit5 --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI + Gemini review (check every ~60s until checks complete): `while ! gh pr checks --repo cuioss/cui-test-mockwebserver-junit5 <pr-number> --watch; do sleep 60; done`
+5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --repo cuioss/cui-test-mockwebserver-junit5 <pr-number> --watch`
 6. **Handle Gemini review comments** — fetch with `gh api repos/cuioss/cui-test-mockwebserver-junit5/pulls/<pr-number>/comments` and for each:
    - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
    - If disagree or out of scope: reply explaining why, then resolve the comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ All cuioss repositories have branch protection on `main`. Direct pushes to `main
 2. Commit changes: `git add <files> && git commit -m "<message>"`
 3. Push the branch: `git push -u origin <branch-name>`
 4. Create a PR: `gh pr create --repo cuioss/cui-test-mockwebserver-junit5 --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --repo cuioss/cui-test-mockwebserver-junit5 <pr-number> --watch`
+5. Wait for CI + Gemini review (waits until checks complete): `gh pr checks --watch`
 6. **Handle Gemini review comments** — fetch with `gh api repos/cuioss/cui-test-mockwebserver-junit5/pulls/<pr-number>/comments` and for each:
    - If clearly valid and fixable: fix it, commit, push, then reply explaining the fix and resolve the comment
    - If disagree or out of scope: reply explaining why, then resolve the comment


### PR DESCRIPTION
## Summary
- Replace redundant `while ! gh pr checks --watch; do sleep 60; done` with `gh pr checks --watch`
- `gh pr checks --watch` already blocks until checks complete, making the while-loop unnecessary
- The old pattern could also loop forever on legitimate check failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)