### PR TITLE
docs: withdraw finding A6 and decision D-1 in review-26-07-04 (verified incorrect)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -7,9 +7,8 @@ below is verified as fixed** (see [Final Verification](#final-verification--docu
 
 **Baseline at time of review** (commit `9f8cd77`, version `1.6-SNAPSHOT`):
 
-- `./mvnw -Ppre-commit clean install` passes (exit 0, all tests green).
-- However, the pre-commit linter/rewrite recipes leave the working tree **dirty**: 32 files
-  modified (formatting, import order, and a `maven.compiler.release` 17 → 21 bump). See A6.
+- `./mvnw -Ppre-commit clean install` passes (exit 0; 36 test classes, 0 failures, 0 errors;
+  javadoc jar builds) and leaves the working tree **clean** — no lint/rewrite drift.
 
 Finding IDs are stable and referenced by the PR clusters in the [Fix Plan](#3-fix-plan).
 Severity: **[C]** critical, **[M]** major, **[m]** minor.
@@ -27,10 +26,10 @@ Severity: **[C]** critical, **[M]** major, **[m]** minor.
 | A3 | m | `CombinedDispatcher.java:27`, `DispatcherResolverTest.java:23`, others | `org.jetbrains.annotations.NotNull` used without a declared dependency (arrives transitively via `kotlin-stdlib`); inconsistent with the project's Lombok `@NonNull` convention. | Replace with `lombok.NonNull` everywhere. |
 | A4 | m | `pom.xml:95-98` | Explicit test-scoped `junit-jupiter-params` is redundant — the `junit-jupiter` aggregate (from parent BOM) already includes it. | Remove the entry. |
 | A5 | m | `pom.xml:89-92` | `jakarta.servlet-api` scope (`provided`) is inherited invisibly from `dependencyManagement`. | Declare `<scope>provided</scope>` at the dependency. |
-| A6 | M | whole tree | Running the documented pre-commit build (`./mvnw -Ppre-commit clean install`) modifies 32 files — the repo has drifted from its own linter. Includes a `maven.compiler.release` 17 → 21 bump from the cui-rewrite recipes. | Run the pre-commit build once, review, and commit the drift. See [Decision D-1](#2-open-decisions) for the 17 → 21 bump. |
+| A6 | — | — | **Withdrawn.** An earlier revision of this document claimed the pre-commit build leaves 32 files modified (incl. a `maven.compiler.release` 17 → 21 bump). Verified incorrect on 2026-07-04: the build passes and leaves the working tree clean; `maven.compiler.release` stays 17. No action. | — |
 | A7 | m | `.github/dependabot.yml` | No `package-ecosystem: github-actions` entry; SHA-pinned `cuioss/cuioss-organization` reusables only advance via org-driven chore PRs. | Add the ecosystem block — or explicitly leave as-is if org automation is the intended sole updater (git history suggests it is; then close as "won't fix"). |
 | A8 | M | many main files | OpenRewrite scanner markers (`/*~~(TODO: Catch specific not Exception ... )~~>*/`, `/*~~(TODO: INFO needs LogRecord ...)~~>*/`) are committed into production sources: `MockWebServerExtension` (8×), `DispatcherResolver` (3×), `CertificateResolver` (4×), `URIBuilder:99`, `KeyMaterialUtil` (2×), `MockResponseConfigResolver` (4×), `CombinedDispatcher` (3×). They flag a real smell: pervasive `catch (Exception)` and INFO-level logging. | Each fix PR that touches a file resolves the underlying issue (narrow the catch or add the documented `// cui-rewrite:disable` suppression) and strips the marker. PR-1 sweeps any file no other cluster touches. |
-| A9 | m | misc | Cosmetics: `HttpMethodMapper` GET enum body mis-indented; `MockWebServerExtension.java:442` declares `parameterResolvers` field mid-class between methods; `lombok.config` lacks trailing newline. | Fix alongside A6 lint commit. |
+| A9 | m | misc | Cosmetics: `HttpMethodMapper` GET enum body mis-indented; `MockWebServerExtension.java:442` declares `parameterResolvers` field mid-class between methods; `lombok.config` lacks trailing newline. | Fix in PR-1. |
 
 ### B. Extension lifecycle & HTTPS (`MockWebServerExtension`, `CertificateResolver`)
 
@@ -136,7 +135,7 @@ Recommendations included — fix sessions should follow these unless the maintai
 
 | ID | Decision | Recommendation |
 |----|----------|----------------|
-| D-1 | `maven.compiler.release` 17 → 21 (forced by the parent's cui-rewrite recipe, A6) | **Accept 21.** The org tooling actively rewrites to 21; pinning 17 would fight the parent on every build. Flag in release notes: consumers need JRE 21+. If 17 support is still required, the recipe must be suppressed in the parent instead — escalate to the maintainer in the PR description. |
+| D-1 | — | **Withdrawn with A6.** No 17 → 21 rewrite happens; `maven.compiler.release` remains 17. Nothing to decide. |
 | D-2 | Nested-class annotation precedence (B2): keep "outer wins" (current, pinned by a test) or switch to "most-specific wins"? | **Most-specific wins.** It matches JUnit conventions and user expectations (`@Nested` with its own `@EnableMockWebServer(useHttps=true)` must be honored). Update the pinning test, note in Migration.adoc. |
 | D-3 | `URIBuilder` encoding (F1): start percent-encoding (behavior change) or only document raw behavior? | **Encode.** Current behavior throws or silently corrupts — nobody can depend on it usefully. Encode query names/values and path segments; document in javadoc + note in Migration.adoc. |
 | D-4 | POST/PUT default status codes (G11): change code to match docs (breaking) or docs to match code? | **Docs to code.** Existing tests pin POST→200/PUT→201; changing runtime behavior of a published test library breaks consumers' assertions. Fix the three wrong javadoc locations. |
@@ -158,7 +157,7 @@ end-to-end workflow**:
 3. Add/adjust tests in the same PR — every behavior fix ships with the regression test that
    would have caught it (H14 mapping).
 4. Verify locally: `./mvnw -Ppre-commit clean install` must pass **and leave the working tree
-   clean** (after PR-1 establishes the clean baseline).
+   clean** (true at baseline — keep it that way).
 5. Push, create the PR against `main` (title prefix `fix:`/`chore:`/`docs:` as appropriate;
    reference the finding IDs from this document in the PR body).
 6. **Wait ~5 minutes** for CI and the Gemini review to arrive (`gh pr checks --watch`).
@@ -174,9 +173,8 @@ must come last (they depend on the behavior decisions landing first).
 
 ### PR-1 — `fix/build-and-lint-baseline` (chore)
 
-**Scope:** A1–A7, A9, remaining A8 markers in files no later cluster touches.
+**Scope:** A1–A5, A7, A9, remaining A8 markers in files no later cluster touches (A6/D-1 withdrawn).
 
-- Apply the pre-commit lint/rewrite drift as its own commit (A6, includes D-1 → release 21).
 - pom.xml: swap `mockwebserver3-junit5` → `mockwebserver3` (A1); clean `dependencyManagement`
   scopes (A2, A5); drop `junit-jupiter-params` (A4).
 - Replace `org.jetbrains.annotations.NotNull` with `lombok.NonNull` (A3).


### PR DESCRIPTION
## Summary

Follow-up correction to #57. Post-merge verification of the completed baseline build (`./mvnw -Ppre-commit clean install` on `9f8cd77`) showed that finding **A6** — "pre-commit build modifies 32 files, incl. a `maven.compiler.release` 17 → 21 bump" — is **incorrect**: the build passes (36 test classes, 0 failures/errors, javadoc jar builds) and leaves the working tree clean; `maven.compiler.release` remains 17.

Changes to `doc/review-26-07-04.md`:

- Baseline note corrected: build passes **and leaves the tree clean**.
- A6 marked **Withdrawn** with the verification result (ID kept for stability).
- Decision D-1 (17 → 21) withdrawn with it — nothing to decide.
- PR-1 cluster scope updated (A6/D-1 removed); A9 and ground-rule wording adjusted.

All other findings are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAuwwBB5pNswCg3KdUxbhx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAuwwBB5pNswCg3KdUxbhx)_