### PR TITLE
fix: correct dispatcher resolution (C1-C6, C11, C12)

### DIFF
--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
@@ -181,10 +181,10 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
     }
 
     /**
-     * @return A new instance of the BaseAllAcceptDispatcher with a default configuration providing an /api endpoint
+     * @return A new instance of the BaseAllAcceptDispatcher with a default configuration providing an /api endpoint.
+     * This is {@code static} so it can be referenced as a {@code @ModuleDispatcher(providerMethod = ...)} target.
      */
-    @SuppressWarnings("unused")  // Implicitly called by the test framework
-    public ModuleDispatcherElement getOptimisticAPIDispatcher() {
+    public static ModuleDispatcherElement getOptimisticAPIDispatcher() {
         return new BaseAllAcceptDispatcher("/api");
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
@@ -85,21 +85,24 @@ public class DispatcherResolver {
     public Dispatcher resolveDispatcher(Class<?> testClass, Object testInstance, Method testMethod) {
         LOGGER.debug("Resolving dispatcher for test class: %s", testClass.getName());
 
-        // Resolve the @ModuleDispatcher annotation (if any) exactly once
-        AnnotationResolution annotationResolution = findModuleDispatcherAnnotation(testClass, testMethod)
+        // Resolve the @ModuleDispatcher annotation (if any) exactly once. The result is either a
+        // ModuleDispatcherElement, a raw Dispatcher, or null (bare annotation / no annotation).
+        Object resolvedAnnotation = findModuleDispatcherAnnotation(testClass, testMethod)
                 .map(annotation -> resolveAnnotation(annotation, testClass))
-                .orElse(AnnotationResolution.empty());
+                .orElse(null);
 
         // Collect all ModuleDispatcherElements from the configured sources
         List<ModuleDispatcherElement> elements = new ArrayList<>();
-        annotationResolution.element().ifPresent(elements::add);
+        if (resolvedAnnotation instanceof ModuleDispatcherElement element) {
+            elements.add(element);
+        }
         if (testInstance != null) {
             resolveFromMethod(testInstance).ifPresent(elements::add);
         }
         elements.addAll(MockResponseConfigResolver.resolveFromAnnotations(testClass, testMethod));
 
         // A provider that returns a raw Dispatcher is exclusive by design
-        if (annotationResolution.directDispatcher().isPresent()) {
+        if (resolvedAnnotation instanceof Dispatcher directDispatcher) {
             if (!elements.isEmpty()) {
                 throw new DispatcherResolutionException(
                         "A @ModuleDispatcher provider returning a raw Dispatcher cannot be combined with other " +
@@ -107,7 +110,7 @@ public class DispatcherResolver {
                                 "sources or return a ModuleDispatcherElement instead.");
             }
             LOGGER.debug("Using directly provided Dispatcher");
-            return annotationResolution.directDispatcher().get();
+            return directDispatcher;
         }
 
         if (!elements.isEmpty()) {
@@ -144,26 +147,23 @@ public class DispatcherResolver {
 
     /**
      * Resolves a {@link ModuleDispatcher} annotation into either a {@link ModuleDispatcherElement},
-     * a raw {@link Dispatcher} (from a provider method), or nothing (bare annotation deferring to
+     * a raw {@link Dispatcher} (from a provider method), or {@code null} (bare annotation deferring to
      * {@code getModuleDispatcher()}).
      *
      * @throws DispatcherResolutionException if the explicitly configured value/provider cannot be resolved
      */
-    private AnnotationResolution resolveAnnotation(ModuleDispatcher annotation, Class<?> testClass) {
+    private Object resolveAnnotation(ModuleDispatcher annotation, Class<?> testClass) {
         // Direct class reference
         if (annotation.value() != ModuleDispatcherElement.class) {
-            return AnnotationResolution.element(instantiate(annotation.value()));
+            return instantiate(annotation.value());
         }
 
         // Provider method (on the provider class, or on the test class when no provider is given)
         if (!annotation.providerMethod().isEmpty()) {
             Class<?> providerClass = annotation.provider() != Object.class ? annotation.provider() : testClass;
             Object result = invokeProviderMethod(providerClass, annotation.providerMethod());
-            if (result instanceof ModuleDispatcherElement element) {
-                return AnnotationResolution.element(element);
-            }
-            if (result instanceof Dispatcher dispatcher) {
-                return AnnotationResolution.direct(dispatcher);
+            if (result instanceof ModuleDispatcherElement || result instanceof Dispatcher) {
+                return result;
             }
             throw new DispatcherResolutionException(
                     "Provider method %s.%s must return a ModuleDispatcherElement or Dispatcher but returned %s"
@@ -178,7 +178,7 @@ public class DispatcherResolver {
         }
 
         // Bare @ModuleDispatcher -> defer to getModuleDispatcher()
-        return AnnotationResolution.empty();
+        return null;
     }
 
     /**
@@ -287,26 +287,6 @@ public class DispatcherResolver {
             String errorMessage = "Dispatcher conflicts found:\n" + String.join("\n", conflicts);
             LOGGER.error(errorMessage);
             throw new IllegalStateException(errorMessage);
-        }
-    }
-
-    /**
-     * The outcome of resolving a {@link ModuleDispatcher} annotation: either a
-     * {@link ModuleDispatcherElement}, a raw {@link Dispatcher}, or nothing.
-     */
-    private record AnnotationResolution(Optional<ModuleDispatcherElement> element,
-                                        Optional<Dispatcher> directDispatcher) {
-
-        static AnnotationResolution empty() {
-            return new AnnotationResolution(Optional.empty(), Optional.empty());
-        }
-
-        static AnnotationResolution element(ModuleDispatcherElement element) {
-            return new AnnotationResolution(Optional.of(element), Optional.empty());
-        }
-
-        static AnnotationResolution direct(Dispatcher dispatcher) {
-            return new AnnotationResolution(Optional.empty(), Optional.of(dispatcher));
         }
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
@@ -21,27 +21,34 @@ import de.cuioss.tools.logging.CuiLogger;
 import lombok.NonNull;
 import mockwebserver3.Dispatcher;
 import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.util.ReflectionUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-
 /**
  * Resolves dispatchers for MockWebServer tests based on annotations and test class methods.
  * <p>
- * This class handles the resolution of dispatchers from:
- * <ul>
- *   <li>{@link ModuleDispatcher} annotations on test classes</li>
- *   <li>Methods in test classes that return {@link ModuleDispatcherElement} instances</li>
- * </ul>
+ * The resolution combines every configured source into a single {@link Dispatcher}:
+ * <ol>
+ *   <li>A {@link ModuleDispatcher} annotation on the current test method or on the test class
+ *       hierarchy (method-level takes precedence over class-level).</li>
+ *   <li>A {@code getModuleDispatcher()} method declared on the test class or any of its
+ *       superclasses.</li>
+ *   <li>{@link MockResponseConfig} annotations resolved for the current test context.</li>
+ * </ol>
+ * <p>
+ * All resolved {@link ModuleDispatcherElement}s are combined into a {@link CombinedDispatcher}.
+ * If none of the sources contribute a dispatcher the default {@code /api} dispatcher is used.
+ * When a source is <em>explicitly configured</em> but cannot be resolved a
+ * {@link DispatcherResolutionException} is thrown instead of silently falling back.
  *
  * @author Oliver Wolff
  * @since 1.1
@@ -50,23 +57,12 @@ public class DispatcherResolver {
 
     private static final CuiLogger LOGGER = new CuiLogger(DispatcherResolver.class);
     private static final String GET_MODULE_DISPATCHER_METHOD = "getModuleDispatcher";
-    private static final String EXCEPTION_DETAILS = "Exception details";
 
     /**
      * Resolves the dispatcher for a test class.
-     * <p>
-     * This method implements the following resolution strategy:
-     * <ol>
-     *   <li>Check for {@link ModuleDispatcher} annotations on the test class</li>
-     *   <li>Check for a {@code getModuleDispatcher()} method in the test class</li>
-     *   <li>If no dispatcher is found, fall back to the default API dispatcher</li>
-     * </ol>
-     * <p>
-     * If multiple dispatchers are found (e.g., from annotations and methods), they will be combined
-     * using {@link CombinedDispatcher}.
      *
      * @param testClass    the class of the test
-     * @param testInstance the instance of the test
+     * @param testInstance the instance of the test, may be {@code null}
      * @return a non-null Dispatcher instance to be used with MockWebServer
      * @since 1.1
      */
@@ -77,342 +73,218 @@ public class DispatcherResolver {
 
     /**
      * Resolves the dispatcher for a test class with context awareness for the current test method.
-     * <p>
-     * This method implements the same resolution strategy as {@link #resolveDispatcher(Class, Object)},
-     * but with additional context awareness for {@link MockResponseConfig} annotations:
-     * <ul>
-     *   <li>When a test method is provided, only annotations relevant to that method's context are included</li>
-     *   <li>This includes annotations on the test method itself and its containing classes</li>
-     *   <li>For nested classes, only annotations in the direct hierarchy are included</li>
-     * </ul>
      *
      * @param testClass    the class of the test
-     * @param testInstance the instance of the test
-     * @param testMethod   the current test method, or null to include all annotations
+     * @param testInstance the instance of the test, may be {@code null}
+     * @param testMethod   the current test method, or {@code null} to include all annotations
      * @return a non-null Dispatcher instance to be used with MockWebServer
+     * @throws DispatcherResolutionException if an explicitly configured source cannot be resolved
      * @since 1.1
      */
     @NonNull
     public Dispatcher resolveDispatcher(Class<?> testClass, Object testInstance, Method testMethod) {
-        LOGGER.info("Resolving dispatcher for test class: %s", testClass.getName());
-        if (testMethod != null) {
-            LOGGER.info("Using context-aware resolution for test method: %s", testMethod.getName());
+        LOGGER.debug("Resolving dispatcher for test class: %s", testClass.getName());
+
+        // Resolve the @ModuleDispatcher annotation (if any) exactly once
+        AnnotationResolution annotationResolution = findModuleDispatcherAnnotation(testClass, testMethod)
+                .map(annotation -> resolveAnnotation(annotation, testClass))
+                .orElse(AnnotationResolution.empty());
+
+        // Collect all ModuleDispatcherElements from the configured sources
+        List<ModuleDispatcherElement> elements = new ArrayList<>();
+        annotationResolution.element().ifPresent(elements::add);
+        if (testInstance != null) {
+            resolveFromMethod(testInstance).ifPresent(elements::add);
+        }
+        elements.addAll(MockResponseConfigResolver.resolveFromAnnotations(testClass, testMethod));
+
+        // A provider that returns a raw Dispatcher is exclusive by design
+        if (annotationResolution.directDispatcher().isPresent()) {
+            if (!elements.isEmpty()) {
+                throw new DispatcherResolutionException(
+                        "A @ModuleDispatcher provider returning a raw Dispatcher cannot be combined with other " +
+                                "dispatcher sources (getModuleDispatcher() or @MockResponseConfig). Remove the additional " +
+                                "sources or return a ModuleDispatcherElement instead.");
+            }
+            LOGGER.debug("Using directly provided Dispatcher");
+            return annotationResolution.directDispatcher().get();
         }
 
-        // Try to resolve from annotation first (highest priority)
-        Optional<Dispatcher> annotationDispatcher = resolveFromAnnotationSource(testClass);
-        if (annotationDispatcher.isPresent()) {
-            return annotationDispatcher.get();
+        if (!elements.isEmpty()) {
+            return createCombinedDispatcher(elements);
         }
 
-        // Collect all dispatchers from different sources
-        List<ModuleDispatcherElement> dispatchers = collectDispatchers(testClass, testInstance, testMethod);
-
-
-        // If we have dispatchers, validate and combine them
-        if (!dispatchers.isEmpty()) {
-            return createCombinedDispatcher(dispatchers);
-        }
-
-        // Fallback to default API dispatcher
-        LOGGER.debug("No dispatchers found, using default API dispatcher");
+        LOGGER.debug("No dispatchers configured, using default /api dispatcher");
         return CombinedDispatcher.createAPIDispatcher();
     }
 
     /**
-     * Attempts to resolve a dispatcher from the ModuleDispatcher annotation.
-     *
-     * @param testClass the test class
-     * @return an Optional containing the resolved dispatcher, or empty if none found
+     * Finds the applicable {@link ModuleDispatcher} annotation. Method-level annotations take
+     * precedence over class-level annotations; the class lookup walks the superclass hierarchy
+     * (via {@link AnnotationSupport}) and the enclosing-class chain for {@code @Nested} tests.
      */
-    private Optional<Dispatcher> resolveFromAnnotationSource(Class<?> testClass) {
-        Optional<ModuleDispatcher> moduleDispatcherAnnotation =
-                AnnotationSupport.findAnnotation(testClass, ModuleDispatcher.class);
-
-        if (moduleDispatcherAnnotation.isEmpty()) {
-            LOGGER.info("No @ModuleDispatcher annotation found on test class: %s", testClass.getName());
-            return Optional.empty();
-        }
-
-        LOGGER.info("Found @ModuleDispatcher annotation on test class: %s", testClass.getName());
-        ModuleDispatcher annotation = moduleDispatcherAnnotation.get();
-
-        // First try to resolve as ModuleDispatcherElement
-        Optional<ModuleDispatcherElement> dispatcher = resolveFromAnnotation(annotation);
-
-        // If a provider method is specified and no dispatcher was resolved directly,
-        // try to resolve using the provider method
-        if (dispatcher.isEmpty() && !annotation.providerMethod().isEmpty()) {
-            LOGGER.info("Attempting to resolve dispatcher from provider method: %s",
-                    annotation.providerMethod());
-            Optional<Dispatcher> directDispatcher =
-                    resolveDirectDispatcher(testClass, annotation.providerMethod());
-            if (directDispatcher.isPresent()) {
-                LOGGER.info("Successfully resolved direct dispatcher from provider method");
-                return directDispatcher;
+    private Optional<ModuleDispatcher> findModuleDispatcherAnnotation(Class<?> testClass, Method testMethod) {
+        if (testMethod != null) {
+            Optional<ModuleDispatcher> onMethod = AnnotationSupport.findAnnotation(testMethod, ModuleDispatcher.class);
+            if (onMethod.isPresent()) {
+                LOGGER.debug("Found method-level @ModuleDispatcher on %s", testMethod.getName());
+                return onMethod;
             }
-            LOGGER.info("Could not resolve direct dispatcher from provider method");
         }
-
+        Class<?> current = testClass;
+        while (current != null) {
+            Optional<ModuleDispatcher> onClass = AnnotationSupport.findAnnotation(current, ModuleDispatcher.class);
+            if (onClass.isPresent()) {
+                return onClass;
+            }
+            current = current.getEnclosingClass();
+        }
         return Optional.empty();
     }
 
     /**
-     * Collects dispatchers from various sources with context awareness for the current test method.
+     * Resolves a {@link ModuleDispatcher} annotation into either a {@link ModuleDispatcherElement},
+     * a raw {@link Dispatcher} (from a provider method), or nothing (bare annotation deferring to
+     * {@code getModuleDispatcher()}).
      *
-     * @param testClass    the test class
-     * @param testInstance the test instance
-     * @param testMethod   the current test method, or null to include all annotations
-     * @return a list of collected dispatchers
+     * @throws DispatcherResolutionException if the explicitly configured value/provider cannot be resolved
      */
-    private List<ModuleDispatcherElement> collectDispatchers(Class<?> testClass, Object testInstance, Method testMethod) {
-        List<ModuleDispatcherElement> dispatchers = new ArrayList<>();
-
-        // Add dispatcher from annotation if present
-        Optional<ModuleDispatcher> moduleDispatcherAnnotation =
-                AnnotationSupport.findAnnotation(testClass, ModuleDispatcher.class);
-        moduleDispatcherAnnotation.flatMap(this::resolveFromAnnotation).ifPresent(dispatcher -> {
-            LOGGER.info("Successfully resolved dispatcher from annotation");
-            dispatchers.add(dispatcher);
-        });
-
-        // Add dispatcher from method if present
-        LOGGER.info("Checking for getModuleDispatcher method in test class: %s", testClass.getName());
-        resolveFromMethod(testInstance).ifPresent(dispatcher -> {
-            LOGGER.info("Successfully resolved dispatcher from getModuleDispatcher method");
-            dispatchers.add(dispatcher);
-        });
-
-        // Add dispatchers from MockResponseConfig annotations
-        List<ModuleDispatcherElement> mockResponseDispatchers =
-                MockResponseConfigResolver.resolveFromAnnotations(testClass, testMethod);
-        if (!mockResponseDispatchers.isEmpty()) {
-            LOGGER.debug("Found %s @MockResponseConfig annotations for context: %s",
-                    mockResponseDispatchers.size(), testMethod != null ? testMethod.getName() : "all");
-            dispatchers.addAll(mockResponseDispatchers);
+    private AnnotationResolution resolveAnnotation(ModuleDispatcher annotation, Class<?> testClass) {
+        // Direct class reference
+        if (annotation.value() != ModuleDispatcherElement.class) {
+            return AnnotationResolution.element(instantiate(annotation.value()));
         }
 
-        return dispatchers;
+        // Provider method (on the provider class, or on the test class when no provider is given)
+        if (!annotation.providerMethod().isEmpty()) {
+            Class<?> providerClass = annotation.provider() != Object.class ? annotation.provider() : testClass;
+            Object result = invokeProviderMethod(providerClass, annotation.providerMethod());
+            if (result instanceof ModuleDispatcherElement element) {
+                return AnnotationResolution.element(element);
+            }
+            if (result instanceof Dispatcher dispatcher) {
+                return AnnotationResolution.direct(dispatcher);
+            }
+            throw new DispatcherResolutionException(
+                    "Provider method %s.%s must return a ModuleDispatcherElement or Dispatcher but returned %s"
+                            .formatted(providerClass.getName(), annotation.providerMethod(),
+                                    result == null ? "null" : result.getClass().getName()));
+        }
+
+        // Provider class without a method name is a misconfiguration
+        if (annotation.provider() != Object.class) {
+            throw new DispatcherResolutionException(
+                    "@ModuleDispatcher declares provider %s but no providerMethod".formatted(annotation.provider().getName()));
+        }
+
+        // Bare @ModuleDispatcher -> defer to getModuleDispatcher()
+        return AnnotationResolution.empty();
     }
 
+    /**
+     * Instantiates a {@link ModuleDispatcherElement} through its no-arg constructor.
+     *
+     * @throws DispatcherResolutionException if the class cannot be instantiated
+     */
+    private ModuleDispatcherElement instantiate(Class<? extends ModuleDispatcherElement> dispatcherClass) {
+        try {
+            Constructor<? extends ModuleDispatcherElement> constructor = dispatcherClass.getDeclaredConstructor();
+            return constructor.newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new DispatcherResolutionException(
+                    "Could not instantiate ModuleDispatcherElement %s. A public no-arg constructor is required."
+                            .formatted(dispatcherClass.getName()), e);
+        }
+    }
 
     /**
-     * Creates a combined dispatcher from the given list of dispatchers.
+     * Looks up and invokes a provider method on the given class, supporting both static and
+     * instance methods.
      *
-     * @param dispatchers the list of dispatchers to combine
-     * @return the combined dispatcher
+     * @throws DispatcherResolutionException if the method is missing or its invocation fails
+     */
+    private Object invokeProviderMethod(Class<?> providerClass, String methodName) {
+        Method method = ReflectionUtils.findMethod(providerClass, methodName)
+                .orElseThrow(() -> new DispatcherResolutionException(
+                        "Provider method %s not found on %s".formatted(methodName, providerClass.getName())));
+        try {
+            Object target = Modifier.isStatic(method.getModifiers()) ? null : ReflectionUtils.newInstance(providerClass);
+            return ReflectionUtils.invokeMethod(method, target);
+        } catch (RuntimeException e) {
+            throw new DispatcherResolutionException(
+                    "Provider method %s.%s could not be invoked: %s".formatted(providerClass.getName(), methodName, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Creates a combined dispatcher from the resolved elements after validating them.
      */
     private Dispatcher createCombinedDispatcher(List<ModuleDispatcherElement> dispatchers) {
-        // Validate uniqueness of path+method combinations
         validateDispatchers(dispatchers);
-
-        // Log active dispatcher elements
-        logActiveDispatchers(dispatchers);
-
         LOGGER.debug("Creating CombinedDispatcher with %s module dispatchers", dispatchers.size());
-        CombinedDispatcher combinedDispatcher = new CombinedDispatcher();
-        combinedDispatcher.addDispatcher(dispatchers);
-        return combinedDispatcher;
+        return new CombinedDispatcher().addDispatcher(dispatchers);
     }
 
     /**
-     * Resolves a dispatcher from a {@link ModuleDispatcher} annotation.
-     * <p>
-     * This method attempts to create a {@link ModuleDispatcherElement} instance using one of the following strategies:
-     * <ol>
-     *   <li>If {@link ModuleDispatcher#value()} is specified, create an instance of that class using its no-arg constructor</li>
-     *   <li>If {@link ModuleDispatcher#provider()} and {@link ModuleDispatcher#providerMethod()} are specified, invoke that method to get an instance</li>
-     * </ol>
-     * <p>
-     * Any exceptions during resolution are logged and result in an empty Optional being returned.
-     *
-     * @param annotation the annotation to resolve from
-     * @return an Optional containing the resolved dispatcher, or empty if resolution fails
-     * @since 1.1
-     */
-    private Optional<ModuleDispatcherElement> resolveFromAnnotation(ModuleDispatcher annotation) {
-        // Check for direct class reference
-        if (annotation.value() != ModuleDispatcherElement.class) {
-            try {
-                LOGGER.debug("Creating dispatcher from class: %s", annotation.value().getName());
-                Constructor<? extends ModuleDispatcherElement> constructor = annotation.value().getDeclaredConstructor();
-                // Constructor accessibility needed for reflection
-                return Optional.of(constructor.newInstance());
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.error("Failed to instantiate dispatcher class: %s", e.getMessage());
-                LOGGER.debug(EXCEPTION_DETAILS, e);
-                return Optional.empty();
-            }
-        }
-
-        // Check for provider class and method
-        if (annotation.provider() != Object.class && !annotation.providerMethod().isEmpty()) {
-            try {
-                LOGGER.debug("Creating dispatcher from provider: %s.%s",
-                        annotation.provider().getName(), annotation.providerMethod());
-
-                Method providerMethod = annotation.provider().getDeclaredMethod(annotation.providerMethod());
-                // Method accessibility needed for reflection
-
-                Object result;
-                if (Modifier.isStatic(providerMethod.getModifiers())) {
-                    // Static method
-                    result = providerMethod.invoke(null);
-                } else {
-                    // Instance method - try to create an instance
-                    Constructor<?> constructor = annotation.provider().getDeclaredConstructor();
-                    // Constructor accessibility needed for reflection
-                    Object providerInstance = constructor.newInstance();
-                    result = providerMethod.invoke(providerInstance);
-                }
-
-                if (result instanceof ModuleDispatcherElement moduleDispatcherElement) {
-                    return Optional.of(moduleDispatcherElement);
-                } else if (result instanceof Dispatcher) {
-                    // The provider method returned a Dispatcher directly
-                    // This is for backward compatibility with the refactored code
-                    LOGGER.debug("Provider method returned a Dispatcher directly, not wrapping it");
-                    // We'll handle this in the resolveDispatcher method
-                    return Optional.empty();
-                } else {
-                    LOGGER.error("Provider method did not return a ModuleDispatcherElement or Dispatcher: %s", result);
-                    return Optional.empty();
-                }
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.error("Failed to invoke provider method: %s", e.getMessage());
-                LOGGER.debug(EXCEPTION_DETAILS, e);
-                return Optional.empty();
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    /**
-     * Resolves a dispatcher from a method in the test class.
-     * <p>
-     * This method looks for a {@code getModuleDispatcher()} method in the test class and invokes it
-     * to obtain a {@link ModuleDispatcherElement} instance. If the method doesn't exist, an empty Optional is returned.
-     * <p>
-     * If the method exists but there are issues with invocation or the return type, appropriate exceptions are thrown:
-     * <ul>
-     *   <li>If the method returns null, an IllegalStateException is thrown</li>
-     *   <li>If the method returns a non-ModuleDispatcherElement, an IllegalStateException is thrown</li>
-     *   <li>If the method throws an exception, an IllegalStateException wrapping the original exception is thrown</li>
-     *   <li>If the method cannot be accessed, an IllegalStateException is thrown</li>
-     * </ul>
+     * Resolves a dispatcher from a {@code getModuleDispatcher()} method declared on the test class
+     * or any of its superclasses.
      *
      * @param testInstance the test instance to invoke the method on
-     * @return an Optional containing the resolved dispatcher, or empty if the method doesn't exist
-     * @throws DispatcherResolutionException if there are issues with method invocation or return type
-     * @since 1.1
+     * @return an Optional containing the resolved dispatcher, or empty if the method does not exist
+     * @throws DispatcherResolutionException if the method exists but cannot be invoked or returns an invalid value
      */
     private Optional<ModuleDispatcherElement> resolveFromMethod(Object testInstance) {
-        LOGGER.info("Attempting to resolve dispatcher from method for class: %s",
-                testInstance.getClass().getName());
-        try {
-            Method method = testInstance.getClass().getDeclaredMethod(GET_MODULE_DISPATCHER_METHOD);
-
-            LOGGER.info("Found getModuleDispatcher method in test class: %s",
-                    testInstance.getClass().getName());
-
-            ModuleDispatcherElement result = invokeModuleDispatcherMethod(testInstance, method);
-            LOGGER.info("Successfully resolved dispatcher from method");
-            return Optional.of(result);
-
-        } catch (NoSuchMethodException e) {
-            // Method doesn't exist, which is fine
-            LOGGER.info("No getModuleDispatcher method found in test class: %s",
-                    testInstance.getClass().getName());
+        Optional<Method> method = ReflectionUtils.findMethod(testInstance.getClass(), GET_MODULE_DISPATCHER_METHOD);
+        if (method.isEmpty()) {
+            LOGGER.debug("No getModuleDispatcher method found on %s", testInstance.getClass().getName());
             return Optional.empty();
-        } catch (SecurityException e) {
-            LOGGER.error(e, "Security violation accessing getModuleDispatcher method");
-            throw new DispatcherResolutionException("Security violation accessing getModuleDispatcher method", e);
         }
+        return Optional.of(invokeModuleDispatcherMethod(testInstance, method.get()));
     }
 
     /**
-     * Invokes the getModuleDispatcher method on the test instance.
-     * This method respects Java's access control rules - if the method is private or otherwise
-     * not accessible, an IllegalAccessException will be thrown and converted to a
-     * DispatcherResolutionException.
-     *
-     * @param testInstance the test instance to invoke the method on
-     * @param method       the method to invoke
-     * @return the ModuleDispatcherElement if successfully resolved
-     * @throws DispatcherResolutionException if there are issues with method invocation or return type
+     * Invokes the {@code getModuleDispatcher} method. Access rules are respected: only public
+     * methods are made accessible, so an inaccessible method results in a
+     * {@link DispatcherResolutionException} rather than silently succeeding.
      */
-    @SuppressWarnings("java:S3011") // owolff: Setting accessibility is ok for test methods
+    @SuppressWarnings("java:S3011") // owolff: Setting accessibility is ok for public test methods
     private ModuleDispatcherElement invokeModuleDispatcherMethod(Object testInstance, Method method) {
-        LOGGER.info("Invoking getModuleDispatcher method on instance of class: %s",
-                testInstance.getClass().getName());
         try {
-            // Check if the method is public but still not accessible (due to Java module system or other reasons)
-            // We only make public methods accessible, but leave private methods inaccessible
-            // This allows tests to verify that inaccessible private methods are properly handled
             if (Modifier.isPublic(method.getModifiers()) && !method.canAccess(testInstance)) {
-                LOGGER.info("Making public getModuleDispatcher method accessible");
                 method.setAccessible(true);
             }
 
             Object result = method.invoke(testInstance);
             if (result == null) {
-                LOGGER.error("getModuleDispatcher method returned null");
                 throw new DispatcherResolutionException("getModuleDispatcher method returned null");
             }
-
-            LOGGER.info("getModuleDispatcher method returned an object of type: %s",
-                    result.getClass().getName());
-
-            // Check if the result implements ModuleDispatcherElement interface
             if (result instanceof ModuleDispatcherElement moduleDispatcherElement) {
-                LOGGER.info("Successfully resolved ModuleDispatcherElement with base URL: %s",
+                LOGGER.debug("Resolved ModuleDispatcherElement from getModuleDispatcher with base URL: %s",
                         moduleDispatcherElement.getBaseUrl());
-
-                // Log supported methods for debugging
-                LOGGER.info("ModuleDispatcherElement supports methods: %s",
-                        moduleDispatcherElement.supportedMethods());
-
                 return moduleDispatcherElement;
-            } else {
-                LOGGER.error("getModuleDispatcher method returned an object of type %s which is not a ModuleDispatcherElement",
-                        result.getClass().getName());
-                throw new DispatcherResolutionException(
-                        "getModuleDispatcher method did not return a ModuleDispatcherElement: " +
-                                result.getClass().getName());
             }
+            throw new DispatcherResolutionException(
+                    "getModuleDispatcher method did not return a ModuleDispatcherElement: " + result.getClass().getName());
         } catch (IllegalAccessException e) {
-            LOGGER.error(e, "Cannot access getModuleDispatcher method");
             throw new DispatcherResolutionException("Cannot access getModuleDispatcher method", e);
         } catch (InvocationTargetException e) {
-            LOGGER.error(e.getCause(), "getModuleDispatcher method threw an exception");
             throw new DispatcherResolutionException("getModuleDispatcher method threw an exception", e.getCause());
         }
     }
 
     /**
-     * Validates that there are no conflicts between dispatchers.
-     * <p>
-     * A conflict occurs when two dispatchers handle the same path and HTTP method.
+     * Validates that no two dispatchers handle the same path and HTTP method.
      *
-     * @param dispatchers the list of dispatchers to validate
      * @throws IllegalStateException if conflicts are found
-     * @since 1.1
      */
     private void validateDispatchers(List<ModuleDispatcherElement> dispatchers) {
         Map<String, List<ModuleDispatcherElement>> pathMethodMap = new HashMap<>();
-
-        // Group dispatchers by path+method combination
         for (ModuleDispatcherElement dispatcher : dispatchers) {
-            String baseUrl = dispatcher.getBaseUrl();
-            // For each supported method, add the dispatcher to the map
             for (HttpMethodMapper method : dispatcher.supportedMethods()) {
-                String key = method + " " + baseUrl;
-                pathMethodMap.computeIfAbsent(key, k -> new ArrayList<>()).add(dispatcher);
+                pathMethodMap.computeIfAbsent(method + " " + dispatcher.getBaseUrl(), k -> new ArrayList<>()).add(dispatcher);
             }
         }
 
-        // Check for conflicts
         List<String> conflicts = pathMethodMap.entrySet().stream()
                 .filter(entry -> entry.getValue().size() > 1)
                 .map(entry -> entry.getKey() + " handled by " + entry.getValue().size() + " dispatchers")
@@ -426,56 +298,22 @@ public class DispatcherResolver {
     }
 
     /**
-     * Attempts to resolve a direct Dispatcher from a provider method.
-     *
-     * @param testClass  the test class containing the provider method
-     * @param methodName the name of the provider method
-     * @return an Optional containing the Dispatcher if found
-     * @since 1.1
+     * The outcome of resolving a {@link ModuleDispatcher} annotation: either a
+     * {@link ModuleDispatcherElement}, a raw {@link Dispatcher}, or nothing.
      */
-    private Optional<Dispatcher> resolveDirectDispatcher(Class<?> testClass, String methodName) {
-        try {
-            Method providerMethod = testClass.getDeclaredMethod(methodName);
-            Object result = providerMethod.invoke(null); // Assuming static method
+    private record AnnotationResolution(Optional<ModuleDispatcherElement> element,
+                                        Optional<Dispatcher> directDispatcher) {
 
-            if (result instanceof Dispatcher directDispatcher) {
-                LOGGER.debug("Found direct Dispatcher from provider method: %s", methodName);
-                return Optional.of(directDispatcher);
-            }
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            LOGGER.debug("Failed to resolve direct Dispatcher: %s", e.getMessage());
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Logs all active dispatcher elements, sorted by path.
-     *
-     * @param dispatchers the list of dispatchers to log
-     * @since 1.1
-     */
-    private void logActiveDispatchers(List<ModuleDispatcherElement> dispatchers) {
-        if (!LOGGER.isInfoEnabled() || dispatchers.isEmpty()) {
-            return;
+        static AnnotationResolution empty() {
+            return new AnnotationResolution(Optional.empty(), Optional.empty());
         }
 
-        LOGGER.info("Active dispatcher elements:");
-
-        // Create a list of log entries sorted by path
-        List<String> logEntries = new ArrayList<>();
-
-        for (ModuleDispatcherElement dispatcher : dispatchers) {
-            String baseUrl = dispatcher.getBaseUrl();
-
-            for (HttpMethodMapper method : dispatcher.supportedMethods()) {
-                String dispatcherName = dispatcher.getClass().getSimpleName();
-                logEntries.add(method + " " + baseUrl + " -> " + dispatcherName);
-            }
+        static AnnotationResolution element(ModuleDispatcherElement element) {
+            return new AnnotationResolution(Optional.of(element), Optional.empty());
         }
 
-        // Sort by path and log
-        logEntries.stream()
-                .sorted(Comparator.comparing(entry -> entry.split(" -> ")[0]))
-                .forEach(entry -> LOGGER.info("- %s", entry));
+        static AnnotationResolution direct(Dispatcher dispatcher) {
+            return new AnnotationResolution(Optional.empty(), Optional.of(dispatcher));
+        }
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
@@ -243,33 +243,26 @@ public class DispatcherResolver {
     }
 
     /**
-     * Invokes the {@code getModuleDispatcher} method. Access rules are respected: only public
-     * methods are made accessible, so an inaccessible method results in a
-     * {@link DispatcherResolutionException} rather than silently succeeding.
+     * Invokes the {@code getModuleDispatcher} method and validates its result. Accessibility is
+     * handled by {@link ReflectionUtils#invokeMethod(Method, Object, Object...)}.
      */
-    @SuppressWarnings("java:S3011") // owolff: Setting accessibility is ok for public test methods
     private ModuleDispatcherElement invokeModuleDispatcherMethod(Object testInstance, Method method) {
+        Object result;
         try {
-            if (Modifier.isPublic(method.getModifiers()) && !method.canAccess(testInstance)) {
-                method.setAccessible(true);
-            }
-
-            Object result = method.invoke(testInstance);
-            if (result == null) {
-                throw new DispatcherResolutionException("getModuleDispatcher method returned null");
-            }
-            if (result instanceof ModuleDispatcherElement moduleDispatcherElement) {
-                LOGGER.debug("Resolved ModuleDispatcherElement from getModuleDispatcher with base URL: %s",
-                        moduleDispatcherElement.getBaseUrl());
-                return moduleDispatcherElement;
-            }
-            throw new DispatcherResolutionException(
-                    "getModuleDispatcher method did not return a ModuleDispatcherElement: " + result.getClass().getName());
-        } catch (IllegalAccessException e) {
-            throw new DispatcherResolutionException("Cannot access getModuleDispatcher method", e);
-        } catch (InvocationTargetException e) {
-            throw new DispatcherResolutionException("getModuleDispatcher method threw an exception", e.getCause());
+            result = ReflectionUtils.invokeMethod(method, testInstance);
+        } catch (RuntimeException e) {
+            throw new DispatcherResolutionException("getModuleDispatcher method threw an exception", e);
         }
+        if (result == null) {
+            throw new DispatcherResolutionException("getModuleDispatcher method returned null");
+        }
+        if (result instanceof ModuleDispatcherElement moduleDispatcherElement) {
+            LOGGER.debug("Resolved ModuleDispatcherElement from getModuleDispatcher with base URL: %s",
+                    moduleDispatcherElement.getBaseUrl());
+            return moduleDispatcherElement;
+        }
+        throw new DispatcherResolutionException(
+                "getModuleDispatcher method did not return a ModuleDispatcherElement: " + result.getClass().getName());
     }
 
     /**

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
@@ -219,6 +219,9 @@ public class DispatcherResolver {
     /**
      * Creates a combined dispatcher from the resolved elements after validating them.
      */
+    // The CombinedDispatcher is returned to the caller and installed on the MockWebServer, which owns
+    // its lifecycle; it holds no closeable resources of its own, so it must not be closed here.
+    @SuppressWarnings("java:S2095") // owolff: dispatcher is returned to and owned by the caller
     private Dispatcher createCombinedDispatcher(List<ModuleDispatcherElement> dispatchers) {
         validateDispatchers(dispatchers);
         LOGGER.debug("Creating CombinedDispatcher with %s module dispatchers", dispatchers.size());

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
@@ -23,7 +23,9 @@ import org.junit.jupiter.api.Nested;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Utility class for resolving {@link MockResponseConfig} annotations from test classes
@@ -45,76 +47,119 @@ public class MockResponseConfigResolver {
     private static final CuiLogger LOGGER = new CuiLogger(MockResponseConfigResolver.class);
 
     /**
-     * Resolves all {@link MockResponseConfig} annotations from the given test class and its methods,
-     * and converts them to {@link MockResponseConfigDispatcherElement} instances.
+     * Resolves all {@link MockResponseConfig} annotations from the given test class and its methods.
      *
      * @param testClass the test class to resolve annotations from, must not be null
      * @return a list of {@link ModuleDispatcherElement} instances created from the annotations
      */
-    public List<ModuleDispatcherElement> resolveFromAnnotations(
-            @NonNull Class<?> testClass) {
+    public List<ModuleDispatcherElement> resolveFromAnnotations(@NonNull Class<?> testClass) {
         return resolveFromAnnotations(testClass, null);
     }
 
     /**
-     * Resolves {@link MockResponseConfig} annotations from the given test class and test method context,
-     * and converts them to {@link MockResponseConfigDispatcherElement} instances.
+     * Resolves {@link MockResponseConfig} annotations from the given test class and test method context.
      * <p>
-     * When a test method is provided, only annotations relevant to that method's context are included:
-     * <ul>
-     *   <li>Annotations on the test method itself</li>
-     *   <li>Annotations on the test method's containing class and its parent classes</li>
-     *   <li>For nested classes, annotations on the class hierarchy up to the test method's class</li>
-     * </ul>
+     * When a test method is provided, only annotations relevant to that method's context are included
+     * (the method itself and the class hierarchy up to the test method's class). Annotations are
+     * de-duplicated by precedence, so a method-level annotation overrides a class-level one that targets
+     * the same path and HTTP method (method &gt; most-specific class &gt; least-specific class).
      *
      * @param testClass  the test class to resolve annotations from, must not be null
      * @param testMethod the current test method context, or null to include all annotations
      * @return a list of {@link ModuleDispatcherElement} instances created from the annotations
      */
-    public List<ModuleDispatcherElement> resolveFromAnnotations(
-            @NonNull Class<?> testClass, Method testMethod) {
-
+    public List<ModuleDispatcherElement> resolveFromAnnotations(@NonNull Class<?> testClass, Method testMethod) {
         List<ModuleDispatcherElement> result = new ArrayList<>();
 
         if (testMethod == null) {
-            // Legacy behavior: collect all annotations
-            // Collect annotations from class hierarchy (including nested classes)
+            // Legacy behavior: collect all annotations from the class hierarchy and all methods
             collectFromClass(testClass, result);
-
-            // Collect annotations from test methods
             collectFromMethods(testClass, result);
         } else {
-            // Context-aware behavior: only collect annotations relevant to the test method
-            // Collect annotations from the test method itself
-            collectFromMethod(testMethod, result);
-
-            // Collect annotations from the class hierarchy up to the test method's class
-            Class<?> methodClass = testMethod.getDeclaringClass();
-            collectFromClassHierarchy(methodClass, result);
+            // Context-aware behavior: collect annotations relevant to the test method,
+            // de-duplicated by precedence.
+            for (MockResponseConfig annotation : collectContextAware(testMethod)) {
+                addConfigElement(annotation, result);
+            }
         }
 
         return result;
     }
 
     /**
-     * Collects {@link MockResponseConfig} annotations from the given class and its nested classes.
-     *
-     * @param clazz  the class to collect annotations from
-     * @param result the list to add the created dispatcher elements to
+     * Collects the {@link MockResponseConfig} annotations relevant to the given test method, ordered
+     * and de-duplicated by precedence (method &gt; most-specific class &gt; least-specific class).
      */
-    private void collectFromClass(Class<?> clazz, List<ModuleDispatcherElement> result) {
-        // Process direct annotations on the class
-        MockResponseConfig[] annotations = clazz.getAnnotationsByType(MockResponseConfig.class);
-        for (MockResponseConfig annotation : annotations) {
-            try {
-                result.add(new MockResponseConfigDispatcherElement(annotation));
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.error(e, "Failed to create MockResponseConfigDispatcherElement from annotation on class %s: %s",
-                        clazz.getName(), e.getMessage());
-            }
+    private List<MockResponseConfig> collectContextAware(Method testMethod) {
+        List<LeveledConfig> leveled = new ArrayList<>();
+
+        // Method-level annotations have the highest precedence (level 0)
+        for (MockResponseConfig annotation : testMethod.getAnnotationsByType(MockResponseConfig.class)) {
+            leveled.add(new LeveledConfig(annotation, 0));
         }
 
-        // Process nested classes
+        // Class hierarchy: most-specific first
+        int level = 1;
+        for (Class<?> clazz : collectContextClasses(testMethod.getDeclaringClass())) {
+            for (MockResponseConfig annotation : clazz.getAnnotationsByType(MockResponseConfig.class)) {
+                leveled.add(new LeveledConfig(annotation, level));
+            }
+            level++;
+        }
+
+        return deduplicateByPrecedence(leveled);
+    }
+
+    /**
+     * Returns the classes that make up the context of the given class, ordered most-specific first
+     * (the class itself, then its enclosing classes, then its superclasses).
+     */
+    private List<Class<?>> collectContextClasses(Class<?> clazz) {
+        List<Class<?>> classes = new ArrayList<>();
+        addContextClasses(clazz, classes);
+        return classes;
+    }
+
+    private void addContextClasses(Class<?> clazz, List<Class<?>> classes) {
+        if (clazz == null || Object.class.equals(clazz) || classes.contains(clazz)) {
+            return;
+        }
+        classes.add(clazz);
+        addContextClasses(clazz.getEnclosingClass(), classes);
+        addContextClasses(clazz.getSuperclass(), classes);
+    }
+
+    /**
+     * Keeps, for every path+method combination, only the annotations declared at the highest
+     * precedence (lowest level). Two annotations at the same level for the same path+method remain in
+     * the result and are later reported as a genuine conflict.
+     */
+    private List<MockResponseConfig> deduplicateByPrecedence(List<LeveledConfig> leveled) {
+        Map<String, Integer> minLevelByKey = new HashMap<>();
+        for (LeveledConfig config : leveled) {
+            minLevelByKey.merge(key(config.annotation()), config.level(), Math::min);
+        }
+
+        List<MockResponseConfig> kept = new ArrayList<>();
+        for (LeveledConfig config : leveled) {
+            if (minLevelByKey.get(key(config.annotation())) == config.level()) {
+                kept.add(config.annotation());
+            }
+        }
+        return kept;
+    }
+
+    private String key(MockResponseConfig annotation) {
+        return annotation.method() + " " + annotation.path();
+    }
+
+    /**
+     * Collects {@link MockResponseConfig} annotations from the given class and its nested classes.
+     */
+    private void collectFromClass(Class<?> clazz, List<ModuleDispatcherElement> result) {
+        for (MockResponseConfig annotation : clazz.getAnnotationsByType(MockResponseConfig.class)) {
+            addConfigElement(annotation, result);
+        }
         for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
             if (nestedClass.isAnnotationPresent(Nested.class)) {
                 collectFromClass(nestedClass, result);
@@ -123,83 +168,39 @@ public class MockResponseConfigResolver {
     }
 
     /**
-     * Collects {@link MockResponseConfig} annotations from the class hierarchy up to a specific class.
-     * This includes the class itself and all its parent classes, but not sibling classes.
-     *
-     * @param clazz  the class to collect annotations from
-     * @param result the list to add the created dispatcher elements to
-     */
-    private void collectFromClassHierarchy(Class<?> clazz, List<ModuleDispatcherElement> result) {
-        // Process direct annotations on the class
-        MockResponseConfig[] annotations = clazz.getAnnotationsByType(MockResponseConfig.class);
-        for (MockResponseConfig annotation : annotations) {
-            try {
-                result.add(new MockResponseConfigDispatcherElement(annotation));
-                LOGGER.debug("Added MockResponseConfig from class %s for path %s",
-                        clazz.getName(), annotation.path());
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.error(e, "Failed to create MockResponseConfigDispatcherElement from annotation on class %s: %s",
-                        clazz.getName(), e.getMessage());
-            }
-        }
-
-        // Process parent class if it's a nested class
-        Class<?> enclosingClass = clazz.getEnclosingClass();
-        if (enclosingClass != null) {
-            collectFromClassHierarchy(enclosingClass, result);
-        }
-
-        // Process superclass if not Object
-        Class<?> superclass = clazz.getSuperclass();
-        if (superclass != null && !Object.class.equals(superclass)) {
-            collectFromClassHierarchy(superclass, result);
-        }
-    }
-
-    /**
-     * Collects {@link MockResponseConfig} annotations from a specific method.
-     *
-     * @param method the method to collect annotations from
-     * @param result the list to add the created dispatcher elements to
-     */
-    private void collectFromMethod(Method method, List<ModuleDispatcherElement> result) {
-        MockResponseConfig[] annotations = method.getAnnotationsByType(MockResponseConfig.class);
-        for (MockResponseConfig annotation : annotations) {
-            try {
-                result.add(new MockResponseConfigDispatcherElement(annotation));
-                LOGGER.debug("Added MockResponseConfig from method %s.%s for path %s",
-                        method.getDeclaringClass().getName(), method.getName(), annotation.path());
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.error("Failed to create MockResponseConfigDispatcherElement from annotation on method %s.%s: %s",
-                        method.getDeclaringClass().getName(), method.getName(), e.getMessage());
-            }
-        }
-    }
-
-    /**
-     * Collects {@link MockResponseConfig} annotations from the methods of the given class.
-     *
-     * @param clazz  the class to collect method annotations from
-     * @param result the list to add the created dispatcher elements to
+     * Collects {@link MockResponseConfig} annotations from the methods of the given class and its
+     * nested classes.
      */
     private void collectFromMethods(Class<?> clazz, List<ModuleDispatcherElement> result) {
         for (Method method : clazz.getDeclaredMethods()) {
-            MockResponseConfig[] annotations = method.getAnnotationsByType(MockResponseConfig.class);
-            for (MockResponseConfig annotation : annotations) {
-                try {
-                    result.add(new MockResponseConfigDispatcherElement(annotation));
-                } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                    LOGGER.error("Failed to create MockResponseConfigDispatcherElement from annotation on method %s.%s: %s",
-                            clazz.getName(), method.getName(), e.getMessage());
-                }
+            for (MockResponseConfig annotation : method.getAnnotationsByType(MockResponseConfig.class)) {
+                addConfigElement(annotation, result);
             }
         }
-
-        // Process methods in nested classes
         for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
             if (nestedClass.isAnnotationPresent(Nested.class)) {
                 collectFromMethods(nestedClass, result);
             }
         }
+    }
+
+    /**
+     * Creates a {@link MockResponseConfigDispatcherElement} from the annotation and adds it to the
+     * result list.
+     */
+    private void addConfigElement(MockResponseConfig annotation, List<ModuleDispatcherElement> result) {
+        try {
+            result.add(new MockResponseConfigDispatcherElement(annotation));
+            LOGGER.debug("Added MockResponseConfig for path %s and method %s", annotation.path(), annotation.method());
+        } catch (IllegalArgumentException e) {
+            LOGGER.error(e, "Failed to create MockResponseConfigDispatcherElement for path %s: %s",
+                    annotation.path(), e.getMessage());
+        }
+    }
+
+    /**
+     * A {@link MockResponseConfig} annotation together with its precedence level (lower is more specific).
+     */
+    private record LeveledConfig(MockResponseConfig annotation, int level) {
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
@@ -135,14 +135,14 @@ public class MockResponseConfigResolver {
      * the result and are later reported as a genuine conflict.
      */
     private List<MockResponseConfig> deduplicateByPrecedence(List<LeveledConfig> leveled) {
-        Map<String, Integer> minLevelByKey = new HashMap<>();
-        for (LeveledConfig config : leveled) {
-            minLevelByKey.merge(key(config.annotation()), config.level(), Math::min);
-        }
-
+        // leveled is ordered by ascending precedence level (0 = method, then class hierarchy), so the
+        // first level recorded for a key is the most specific. Same-level duplicates are retained so a
+        // genuine conflict is still detected later.
+        Map<String, Integer> keptLevelByKey = new HashMap<>();
         List<MockResponseConfig> kept = new ArrayList<>();
         for (LeveledConfig config : leveled) {
-            if (minLevelByKey.get(key(config.annotation())) == config.level()) {
+            Integer keptLevel = keptLevelByKey.putIfAbsent(key(config.annotation()), config.level());
+            if (keptLevel == null || keptLevel.intValue() == config.level()) {
                 kept.add(config.annotation());
             }
         }

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
@@ -19,195 +19,209 @@ import lombok.NonNull;
 import mockwebserver3.Dispatcher;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okio.Buffer;
+import okio.ByteString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Advanced test class for {@link DispatcherResolver} focusing on edge cases and uncovered paths
- * to improve code coverage intelligently.
+ * Advanced tests for {@link DispatcherResolver} covering the resolution edge cases. Where a
+ * dispatcher is expected to resolve, a probe request is dispatched and its response asserted so the
+ * tests distinguish a genuinely resolved dispatcher from the {@code /api} fallback.
  *
- * @author Test Coverage Enhancement
+ * @author Oliver Wolff
  */
-@DisplayName("Advanced DispatcherResolver Tests - Coverage Enhancement")
+@DisplayName("DispatcherResolver - Advanced Resolution Tests")
 class DispatcherResolverAdvancedTest {
 
     private static final DispatcherResolver resolver = new DispatcherResolver();
 
     @Test
-    @DisplayName("Should handle annotation with constructor that throws exception")
-    void shouldHandleAnnotationWithFailingConstructor() {
-        // Arrange
-        var testClass = TestClassWithFailingConstructorDispatcher.class;
-        var testInstance = new TestClassWithFailingConstructorDispatcher();
-
-        // Act - should not throw exception, should fall back to default
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should throw when the annotated dispatcher constructor fails")
+    void shouldThrowOnFailingConstructor() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithFailingConstructorDispatcher.class,
+                        new TestClassWithFailingConstructorDispatcher()));
     }
 
     @Test
-    @DisplayName("Should handle annotation with provider method that throws exception")
-    void shouldHandleAnnotationWithFailingProviderMethod() {
-        // Arrange
-        var testClass = TestClassWithFailingProviderMethod.class;
-        var testInstance = new TestClassWithFailingProviderMethod();
-
-        // Act - should not throw exception, should fall back to default
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should throw when the provider method fails")
+    void shouldThrowOnFailingProviderMethod() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithFailingProviderMethod.class,
+                        new TestClassWithFailingProviderMethod()));
     }
 
     @Test
-    @DisplayName("Should handle annotation with non-static provider method")
-    void shouldHandleAnnotationWithNonStaticProviderMethod() {
-        // Arrange
-        var testClass = TestClassWithNonStaticProviderMethod.class;
-        var testInstance = new TestClassWithNonStaticProviderMethod();
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should resolve a dispatcher from a non-static provider method")
+    void shouldResolveNonStaticProviderMethod() {
+        var dispatcher = resolver.resolveDispatcher(TestClassWithNonStaticProviderMethod.class,
+                new TestClassWithNonStaticProviderMethod());
+        assertResponseBody(dispatcher, "/non-static", "Test Response");
     }
 
     @Test
-    @DisplayName("Should handle annotation with provider method returning wrong type")
-    void shouldHandleAnnotationWithProviderReturningWrongType() {
-        // Arrange
-        var testClass = TestClassWithProviderReturningWrongType.class;
-        var testInstance = new TestClassWithProviderReturningWrongType();
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should resolve a dispatcher from a static provider method (getOptimisticAPIDispatcher)")
+    void shouldResolveStaticProviderMethod() {
+        var dispatcher = resolver.resolveDispatcher(TestClassWithStaticProviderMethod.class,
+                new TestClassWithStaticProviderMethod());
+        // BaseAllAcceptDispatcher for /api answers GET with 200
+        assertStatus(dispatcher, "/api", 200);
     }
 
     @Test
-    @DisplayName("Should detect and throw exception for dispatcher conflicts")
+    @DisplayName("Should throw when the provider method returns the wrong type")
+    void shouldThrowOnProviderReturningWrongType() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithProviderReturningWrongType.class,
+                        new TestClassWithProviderReturningWrongType()));
+    }
+
+    @Test
+    @DisplayName("Should throw when a provider class is given without a provider method")
+    void shouldThrowOnProviderWithoutMethod() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithProviderButNoMethod.class,
+                        new TestClassWithProviderButNoMethod()));
+    }
+
+    @Test
+    @DisplayName("Should throw for dispatcher conflicts")
     void shouldDetectDispatcherConflicts() {
-        // Arrange
-        var testClass = TestClassWithConflictingDispatchers.class;
-        var testInstance = new TestClassWithConflictingDispatchers();
-
-        // Act & Assert
         var exception = assertThrows(IllegalStateException.class, () ->
-                resolver.resolveDispatcher(testClass, testInstance));
-
+                resolver.resolveDispatcher(TestClassWithConflictingDispatchers.class,
+                        new TestClassWithConflictingDispatchers()));
         assertTrue(exception.getMessage().contains("Dispatcher conflicts found"),
                 "Exception message should indicate conflicts: " + exception.getMessage());
     }
 
     @Test
-    @DisplayName("Should handle annotation with no-arg constructor that is not accessible")
-    void shouldHandleAnnotationWithInaccessibleConstructor() {
-        // Arrange
-        var testClass = TestClassWithInaccessibleConstructorDispatcher.class;
-        var testInstance = new TestClassWithInaccessibleConstructorDispatcher();
-
-        // Act - should not throw exception, should fall back to default
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should throw when the annotated dispatcher constructor is inaccessible")
+    void shouldThrowOnInaccessibleConstructor() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithInaccessibleConstructorDispatcher.class,
+                        new TestClassWithInaccessibleConstructorDispatcher()));
     }
 
     @Test
-    @DisplayName("Should handle empty dispatcher list and fall back to default")
-    void shouldHandleEmptyDispatcherList() {
-        // Arrange - class with no annotations or methods
-        var testClass = EmptyTestClass.class;
-        var testInstance = new EmptyTestClass();
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
+    @DisplayName("Should fall back to the default /api dispatcher when nothing is configured")
+    void shouldFallBackToDefault() {
+        var dispatcher = resolver.resolveDispatcher(EmptyTestClass.class, new EmptyTestClass());
         assertInstanceOf(CombinedDispatcher.class, dispatcher);
+        assertStatus(dispatcher, "/api", 200);
+        assertStatus(dispatcher, "/somewhere-else", 418);
     }
 
     @Test
-    @DisplayName("Should handle provider method that does not exist")
-    void shouldHandleNonExistentProviderMethod() {
-        // Arrange
-        var testClass = TestClassWithNonExistentProviderMethod.class;
-        var testInstance = new TestClassWithNonExistentProviderMethod();
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should throw when a configured provider method does not exist")
+    void shouldThrowOnNonExistentProviderMethod() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithNonExistentProviderMethod.class,
+                        new TestClassWithNonExistentProviderMethod()));
     }
 
     @Test
-    @DisplayName("Should handle context-aware resolution with test method")
-    void shouldHandleContextAwareResolution() throws NoSuchMethodException {
-        // Arrange
-        var testClass = TestClassWithMethod.class;
-        var testInstance = new TestClassWithMethod();
-        Method testMethod = this.getClass().getDeclaredMethod("shouldHandleContextAwareResolution");
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance, testMethod);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should resolve from getModuleDispatcher with context-aware resolution")
+    void shouldResolveContextAware() throws NoSuchMethodException {
+        Method testMethod = getClass().getDeclaredMethod("shouldResolveContextAware");
+        var dispatcher = resolver.resolveDispatcher(TestClassWithMethod.class,
+                new TestClassWithMethod(), testMethod);
+        assertResponseBody(dispatcher, "/method", "Method Response");
     }
 
+    @Test
+    @DisplayName("Should resolve a getModuleDispatcher method inherited from a superclass")
+    void shouldResolveInheritedModuleDispatcherMethod() {
+        var dispatcher = resolver.resolveDispatcher(ConcreteTestClass.class, new ConcreteTestClass());
+        assertResponseBody(dispatcher, "/inherited", "Inherited Response");
+    }
 
     @Test
-    @DisplayName("Should handle annotation with provider method returning direct Dispatcher")
-    void shouldHandleProviderMethodReturningDirectDispatcher() {
-        // Arrange
-        var testClass = TestClassWithDirectDispatcherProvider.class;
-        var testInstance = new TestClassWithDirectDispatcherProvider();
+    @DisplayName("Should resolve a method-level @ModuleDispatcher taking precedence over the class")
+    void shouldResolveMethodLevelAnnotation() throws NoSuchMethodException {
+        Method testMethod = MethodLevelAnnotationClass.class.getDeclaredMethod("annotatedTest");
+        var dispatcher = resolver.resolveDispatcher(MethodLevelAnnotationClass.class,
+                new MethodLevelAnnotationClass(), testMethod);
+        assertResponseBody(dispatcher, "/method-level", "Method Level Response");
+    }
 
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        // Should return the direct dispatcher, not wrapped in CombinedDispatcher
+    @Test
+    @DisplayName("Should return the raw Dispatcher provided by a provider method")
+    void shouldReturnDirectDispatcher() {
+        var dispatcher = resolver.resolveDispatcher(TestClassWithDirectDispatcherProvider.class,
+                new TestClassWithDirectDispatcherProvider());
         assertInstanceOf(TestDirectDispatcher.class, dispatcher);
     }
 
     @Test
-    @DisplayName("Should handle public method that is not accessible due to module system")
-    void shouldHandlePublicMethodNotAccessible() {
-        // Arrange
-        var testClass = TestClassWithPublicMethodNotAccessible.class;
-        var testInstance = new TestClassWithPublicMethodNotAccessible();
-
-        // Act
-        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
-
-        // Assert
-        assertNotNull(dispatcher);
-        assertInstanceOf(CombinedDispatcher.class, dispatcher);
+    @DisplayName("Should reject combining a raw Dispatcher provider with other sources")
+    void shouldRejectDirectDispatcherCombinedWithOtherSources() {
+        assertThrows(DispatcherResolutionException.class, () ->
+                resolver.resolveDispatcher(TestClassWithDirectDispatcherAndMethod.class,
+                        new TestClassWithDirectDispatcherAndMethod()));
     }
 
-    // Test classes for various scenarios
+    @Test
+    @DisplayName("Should resolve a bare @ModuleDispatcher via getModuleDispatcher")
+    void shouldResolveBareAnnotationViaMethod() {
+        var dispatcher = resolver.resolveDispatcher(BareAnnotationClass.class, new BareAnnotationClass());
+        assertResponseBody(dispatcher, "/bare", "Bare Response");
+    }
+
+    // --- probe helpers -------------------------------------------------------------------------
+
+    private void assertStatus(Dispatcher dispatcher, String path, int expectedStatus) {
+        var response = dispatch(dispatcher, path);
+        assertTrue(response.getStatus().contains(String.valueOf(expectedStatus)),
+                "Expected status " + expectedStatus + " for path " + path + " but was " + response.getStatus());
+    }
+
+    private void assertResponseBody(Dispatcher dispatcher, String path, String expectedBody) {
+        var response = dispatch(dispatcher, path);
+        assertEquals(expectedBody, readBody(response), "Unexpected body for path " + path);
+    }
+
+    private static MockResponse dispatch(Dispatcher dispatcher, String path) {
+        var request = new RecordedRequest(
+                0, 0, null, Collections.emptyList(),
+                "GET", path, "HTTP/1.1",
+                HttpUrl.parse("http://localhost" + path),
+                Headers.of("Host", "localhost"),
+                ByteString.EMPTY, 0, Collections.emptyList(), null);
+        try {
+            return dispatcher.dispatch(request);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Dispatch was interrupted", e);
+        }
+    }
+
+    private static String readBody(MockResponse response) {
+        if (response.getBody() == null) {
+            return "";
+        }
+        var buffer = new Buffer();
+        try {
+            response.getBody().writeTo(buffer);
+            return buffer.readUtf8();
+        } catch (java.io.IOException e) {
+            throw new IllegalStateException("Failed to read response body", e);
+        }
+    }
+
+    // --- test fixtures -------------------------------------------------------------------------
 
     @ModuleDispatcher(FailingConstructorDispatcher.class)
     static class TestClassWithFailingConstructorDispatcher {
@@ -216,15 +230,19 @@ class DispatcherResolverAdvancedTest {
     @ModuleDispatcher(provider = TestClassWithFailingProviderMethod.class, providerMethod = "failingProvider")
     static class TestClassWithFailingProviderMethod {
         public static ModuleDispatcherElement failingProvider() {
-            /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException("Provider method failed");
+            throw new IllegalStateException("Provider method failed");
         }
     }
 
     @ModuleDispatcher(provider = TestClassWithNonStaticProviderMethod.class, providerMethod = "nonStaticProvider")
     static class TestClassWithNonStaticProviderMethod {
         public ModuleDispatcherElement nonStaticProvider() {
-            return new TestDispatcherElement("/non-static");
+            return new TestDispatcherElement("/non-static", "Test Response");
         }
+    }
+
+    @ModuleDispatcher(provider = BaseAllAcceptDispatcher.class, providerMethod = "getOptimisticAPIDispatcher")
+    static class TestClassWithStaticProviderMethod {
     }
 
     @ModuleDispatcher(provider = TestClassWithProviderReturningWrongType.class, providerMethod = "wrongTypeProvider")
@@ -232,6 +250,10 @@ class DispatcherResolverAdvancedTest {
         public static String wrongTypeProvider() {
             return "Not a dispatcher";
         }
+    }
+
+    @ModuleDispatcher(provider = TestDispatcherElement.class)
+    static class TestClassWithProviderButNoMethod {
     }
 
     @ModuleDispatcher(ConflictingDispatcherElement.class)
@@ -243,10 +265,29 @@ class DispatcherResolverAdvancedTest {
 
     static class TestClassWithMethod {
         public ModuleDispatcherElement getModuleDispatcher() {
-            return new TestDispatcherElement("/method");
+            return new TestDispatcherElement("/method", "Method Response");
         }
     }
 
+    abstract static class AbstractTestClass {
+        public ModuleDispatcherElement getModuleDispatcher() {
+            return new TestDispatcherElement("/inherited", "Inherited Response");
+        }
+    }
+
+    static class ConcreteTestClass extends AbstractTestClass {
+    }
+
+    static class MethodLevelAnnotationClass {
+        @ModuleDispatcher(provider = MethodLevelAnnotationClass.class, providerMethod = "provide")
+        void annotatedTest() {
+            // annotation carrier only
+        }
+
+        public static ModuleDispatcherElement provide() {
+            return new TestDispatcherElement("/method-level", "Method Level Response");
+        }
+    }
 
     @ModuleDispatcher(providerMethod = "provideDirectDispatcher")
     static class TestClassWithDirectDispatcherProvider {
@@ -255,9 +296,21 @@ class DispatcherResolverAdvancedTest {
         }
     }
 
-    static class TestClassWithPublicMethodNotAccessible {
+    @ModuleDispatcher(providerMethod = "provideDirectDispatcher")
+    static class TestClassWithDirectDispatcherAndMethod {
+        public static Dispatcher provideDirectDispatcher() {
+            return new TestDirectDispatcher();
+        }
+
         public ModuleDispatcherElement getModuleDispatcher() {
-            return new TestDispatcherElement("/public-not-accessible");
+            return new TestDispatcherElement("/extra", "Extra Response");
+        }
+    }
+
+    @ModuleDispatcher
+    static class BareAnnotationClass {
+        public ModuleDispatcherElement getModuleDispatcher() {
+            return new TestDispatcherElement("/bare", "Bare Response");
         }
     }
 
@@ -266,28 +319,22 @@ class DispatcherResolverAdvancedTest {
     }
 
     static class EmptyTestClass {
-        // No annotations or methods
     }
 
     @ModuleDispatcher(providerMethod = "nonExistentMethod")
     static class TestClassWithNonExistentProviderMethod {
     }
 
-    // Helper classes
+    // --- helper dispatcher elements ------------------------------------------------------------
 
     static class FailingConstructorDispatcher implements ModuleDispatcherElement {
         public FailingConstructorDispatcher() {
-            /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException("Constructor failed");
+            throw new IllegalStateException("Constructor failed");
         }
 
         @Override
         public String getBaseUrl() {
             return "/failing";
-        }
-
-        @Override
-        public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
-            return Optional.empty();
         }
 
         @Override
@@ -298,17 +345,11 @@ class DispatcherResolverAdvancedTest {
 
     static class InaccessibleConstructorDispatcher implements ModuleDispatcherElement {
         private InaccessibleConstructorDispatcher() {
-            // Private constructor to test accessibility issues
         }
 
         @Override
         public String getBaseUrl() {
             return "/inaccessible";
-        }
-
-        @Override
-        public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
-            return Optional.empty();
         }
 
         @Override
@@ -325,10 +366,7 @@ class DispatcherResolverAdvancedTest {
 
         @Override
         public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
-            return Optional.of(new MockResponse.Builder()
-                    .code(200)
-                    .body("Conflict 1")
-                    .build());
+            return Optional.of(new MockResponse.Builder().code(200).body("Conflict").build());
         }
 
         @Override
@@ -339,9 +377,16 @@ class DispatcherResolverAdvancedTest {
 
     static class TestDispatcherElement implements ModuleDispatcherElement {
         private final String baseUrl;
+        private final String body;
 
-        public TestDispatcherElement(String baseUrl) {
+        @SuppressWarnings("unused") // required so the class is a valid @ModuleDispatcher value target
+        public TestDispatcherElement() {
+            this("/", "default");
+        }
+
+        public TestDispatcherElement(String baseUrl, String body) {
             this.baseUrl = baseUrl;
+            this.body = body;
         }
 
         @Override
@@ -351,10 +396,7 @@ class DispatcherResolverAdvancedTest {
 
         @Override
         public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
-            return Optional.of(new MockResponse.Builder()
-                    .code(200)
-                    .body("Test Response")
-                    .build());
+            return Optional.of(new MockResponse.Builder().code(200).body(body).build());
         }
 
         @Override
@@ -364,13 +406,9 @@ class DispatcherResolverAdvancedTest {
     }
 
     static class TestDirectDispatcher extends Dispatcher {
-        @NonNull
         @Override
-        public MockResponse dispatch(@NonNull RecordedRequest request) {
-            return new MockResponse.Builder()
-                    .code(200)
-                    .body("Direct Dispatcher")
-                    .build();
+        public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
+            return new MockResponse.Builder().code(200).body("Direct Dispatcher").build();
         }
     }
 }

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
@@ -19,15 +19,10 @@ import lombok.NonNull;
 import mockwebserver3.Dispatcher;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okio.Buffer;
-import okio.ByteString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -183,42 +178,14 @@ class DispatcherResolverAdvancedTest {
     // --- probe helpers -------------------------------------------------------------------------
 
     private void assertStatus(Dispatcher dispatcher, String path, int expectedStatus) {
-        var response = dispatch(dispatcher, path);
+        var response = DispatcherTestSupport.dispatch(dispatcher, path);
         assertTrue(response.getStatus().contains(String.valueOf(expectedStatus)),
                 "Expected status " + expectedStatus + " for path " + path + " but was " + response.getStatus());
     }
 
     private void assertResponseBody(Dispatcher dispatcher, String path, String expectedBody) {
-        var response = dispatch(dispatcher, path);
-        assertEquals(expectedBody, readBody(response), "Unexpected body for path " + path);
-    }
-
-    private static MockResponse dispatch(Dispatcher dispatcher, String path) {
-        var request = new RecordedRequest(
-                0, 0, null, Collections.emptyList(),
-                "GET", path, "HTTP/1.1",
-                HttpUrl.parse("http://localhost" + path),
-                Headers.of("Host", "localhost"),
-                ByteString.EMPTY, 0, Collections.emptyList(), null);
-        try {
-            return dispatcher.dispatch(request);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Dispatch was interrupted", e);
-        }
-    }
-
-    private static String readBody(MockResponse response) {
-        if (response.getBody() == null) {
-            return "";
-        }
-        var buffer = new Buffer();
-        try {
-            response.getBody().writeTo(buffer);
-            return buffer.readUtf8();
-        } catch (java.io.IOException e) {
-            throw new IllegalStateException("Failed to read response body", e);
-        }
+        var response = DispatcherTestSupport.dispatch(dispatcher, path);
+        assertEquals(expectedBody, DispatcherTestSupport.readBody(response), "Unexpected body for path " + path);
     }
 
     // --- test fixtures -------------------------------------------------------------------------

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverMethodTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverMethodTest.java
@@ -104,18 +104,18 @@ class DispatcherResolverMethodTest {
     }
 
     @Test
-    @DisplayName("Should throw exception when getModuleDispatcher method is not accessible")
-    void shouldThrowExceptionWhenMethodIsNotAccessible() {
+    @DisplayName("Should resolve a private getModuleDispatcher method")
+    void shouldResolvePrivateMethod() {
         // Arrange
         var testClass = TestClassWithPrivateMethod.class;
         var testInstance = new TestClassWithPrivateMethod();
 
-        // Act & Assert
-        var exception = assertThrows(DispatcherResolutionException.class, () ->
-                resolver.resolveDispatcher(testClass, testInstance));
+        // Act - accessibility is handled by the resolver, so a private method still resolves
+        var dispatcher = resolver.resolveDispatcher(testClass, testInstance);
 
-        assertTrue(exception.getMessage().contains("Cannot access"),
-                "Exception message should indicate access issue: " + exception.getMessage());
+        // Assert
+        assertNotNull(dispatcher);
+        assertInstanceOf(CombinedDispatcher.class, dispatcher);
     }
 
     // Test dispatcher element implementation

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverTest.java
@@ -23,12 +23,6 @@ import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okio.Buffer;
-import okio.ByteString;
-
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -69,31 +63,13 @@ class DispatcherResolverTest {
         assertInstanceOf(CombinedDispatcher.class, dispatcher, "Dispatcher should be a CombinedDispatcher");
 
         // Verify the dispatcher works as expected
-        var response = dispatchRequest(dispatcher, TEST_PATH);
+        var response = DispatcherTestSupport.dispatch(dispatcher, TEST_PATH);
         LOGGER.debug("TEST_PATH Response Status: %s", response.getStatus());
         LOGGER.debug("TEST_PATH Response Body: %s", response.getBody());
         assertTrue(response.getStatus().contains(String.valueOf(200)),
                 response.getStatus() + STATUS_ERROR_MESSAGE);
-        assertTrue(writeBodyToString(response).contains("Test Dispatcher"),
+        assertTrue(DispatcherTestSupport.readBody(response).contains("Test Dispatcher"),
                 "Response body should contain expected content");
-    }
-
-    /**
-     * Helper method to convert a MockResponse body to a string for assertion.
-     *
-     * @param response the MockResponse to extract the body from
-     * @return the body as a string, or an error message if extraction fails
-     */
-    private String writeBodyToString(MockResponse response) {
-        Buffer buffer = new Buffer();
-        try {
-            assert response.getBody() != null;
-            response.getBody().writeTo(buffer);
-            return buffer.readUtf8();
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            LOGGER.error(e, "Failed to read response body: %s", e.getMessage());
-            return "Failed to read response body";
-        }
     }
 
 
@@ -112,12 +88,12 @@ class DispatcherResolverTest {
         assertInstanceOf(CombinedDispatcher.class, dispatcher);
 
         // Verify the dispatcher works as expected
-        var response = dispatchRequest(dispatcher, METHOD_PATH);
+        var response = DispatcherTestSupport.dispatch(dispatcher, METHOD_PATH);
         LOGGER.debug("METHOD_PATH Response Status: %s", response.getStatus());
         LOGGER.debug("METHOD_PATH Response Body: %s", response.getBody());
         assertTrue(response.getStatus().contains(String.valueOf(200)),
                 response.getStatus() + STATUS_ERROR_MESSAGE);
-        assertTrue(writeBodyToString(response).contains("Method Dispatcher"));
+        assertTrue(DispatcherTestSupport.readBody(response).contains("Method Dispatcher"));
     }
 
     @Test
@@ -135,12 +111,12 @@ class DispatcherResolverTest {
         assertInstanceOf(TestDispatcher.class, dispatcher);
 
         // Verify the dispatcher works as expected
-        var response = dispatchRequest(dispatcher, LEGACY_PATH);
+        var response = DispatcherTestSupport.dispatch(dispatcher, LEGACY_PATH);
         LOGGER.debug("LEGACY_PATH Response Status: %s", response.getStatus());
         LOGGER.debug("LEGACY_PATH Response Body: %s", response.getBody());
         assertTrue(response.getStatus().contains(String.valueOf(200)),
                 response.getStatus() + STATUS_ERROR_MESSAGE);
-        assertTrue(writeBodyToString(response).contains("Legacy Dispatcher"));
+        assertTrue(DispatcherTestSupport.readBody(response).contains("Legacy Dispatcher"));
     }
 
     @Test
@@ -164,23 +140,6 @@ class DispatcherResolverTest {
     private static final String LEGACY_PATH = "/legacy";
     private static final String STATUS_ERROR_MESSAGE = " does not contain 200";
 
-    /**
-     * Helper method to dispatch a request to a dispatcher
-     */
-    private static MockResponse dispatchRequest(Dispatcher dispatcher, String path) {
-        try {
-            // Create a request with the path directly
-            var request = new RecordedRequest(
-                    0, 0, null, Collections.emptyList(),
-                    "GET", path, "HTTP/1.1",
-                    HttpUrl.parse("http://localhost" + path),
-                    Headers.of("Host", "localhost"),
-                    ByteString.EMPTY, 0, Collections.emptyList(), null);
-            return dispatcher.dispatch(request);
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            throw new IllegalStateException("Failed to dispatch request", e);
-        }
-    }
 
 
     // Test classes for the tests

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherTestSupport.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherTestSupport.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.mockwebserver.dispatcher;
+
+import mockwebserver3.Dispatcher;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okio.Buffer;
+import okio.ByteString;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Shared helpers for dispatcher tests: building a {@link RecordedRequest}, dispatching it, and
+ * reading a {@link MockResponse} body. Centralised here so the tests do not each hand-build the
+ * multi-argument {@code RecordedRequest}.
+ */
+public final class DispatcherTestSupport {
+
+    private DispatcherTestSupport() {
+    }
+
+    /**
+     * Creates a GET {@link RecordedRequest} for the given path.
+     */
+    public static RecordedRequest getRequest(String path) {
+        return new RecordedRequest(
+                0, 0, null, Collections.emptyList(),
+                "GET", path, "HTTP/1.1",
+                HttpUrl.parse("http://localhost" + path),
+                Headers.of("Host", "localhost"),
+                ByteString.EMPTY, 0, Collections.emptyList(), null);
+    }
+
+    /**
+     * Dispatches a GET request for the given path against the dispatcher.
+     */
+    public static MockResponse dispatch(Dispatcher dispatcher, String path) {
+        try {
+            return dispatcher.dispatch(getRequest(path));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Dispatch was interrupted", e);
+        }
+    }
+
+    /**
+     * Reads the body of the response as a UTF-8 string, or an empty string if there is no body.
+     */
+    public static String readBody(MockResponse response) {
+        if (response.getBody() == null) {
+            return "";
+        }
+        var buffer = new Buffer();
+        try {
+            response.getBody().writeTo(buffer);
+            return buffer.readUtf8();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read response body", e);
+        }
+    }
+}

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.mockwebserver.mockresponse;
+
+import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
+import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
+import mockwebserver3.MockResponse;
+import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okio.Buffer;
+import okio.ByteString;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that context-aware {@link MockResponseConfig} resolution de-duplicates by precedence so a
+ * method-level annotation overrides a class-level one for the same path and HTTP method (finding C4).
+ *
+ * @author Oliver Wolff
+ */
+@DisplayName("MockResponseConfig precedence resolution")
+class MockResponseConfigPrecedenceTest {
+
+    @MockResponseConfig(path = "/data", method = HttpMethodMapper.GET, textContent = "class-level", status = 200)
+    static class OverrideFixture {
+        @MockResponseConfig(path = "/data", method = HttpMethodMapper.GET, textContent = "method-level", status = 200)
+        void overriding() {
+            // annotation carrier only
+        }
+    }
+
+    @MockResponseConfig(path = "/class-only", method = HttpMethodMapper.GET, textContent = "class", status = 200)
+    static class DistinctFixture {
+        @MockResponseConfig(path = "/method-only", method = HttpMethodMapper.GET, textContent = "method", status = 200)
+        void distinct() {
+            // annotation carrier only
+        }
+    }
+
+    @Test
+    @DisplayName("Method-level annotation overrides class-level for the same path and method")
+    void methodOverridesClass() throws NoSuchMethodException {
+        Method method = OverrideFixture.class.getDeclaredMethod("overriding");
+        List<ModuleDispatcherElement> elements =
+                MockResponseConfigResolver.resolveFromAnnotations(OverrideFixture.class, method);
+
+        assertEquals(1, elements.size(), "Duplicate path+method must be de-duplicated to a single element");
+        assertEquals("method-level", body(elements.get(0), "/data"),
+                "The method-level annotation must win over the class-level one");
+    }
+
+    @Test
+    @DisplayName("Distinct path+method combinations are all retained")
+    void distinctCombinationsRetained() throws NoSuchMethodException {
+        Method method = DistinctFixture.class.getDeclaredMethod("distinct");
+        List<ModuleDispatcherElement> elements =
+                MockResponseConfigResolver.resolveFromAnnotations(DistinctFixture.class, method);
+
+        assertEquals(2, elements.size(), "Distinct path+method combinations must be kept");
+    }
+
+    @Test
+    @DisplayName("Legacy resolution (no test method) collects class and method annotations")
+    void legacyCollectsAll() {
+        List<ModuleDispatcherElement> elements =
+                MockResponseConfigResolver.resolveFromAnnotations(DistinctFixture.class);
+
+        assertEquals(2, elements.size(), "Legacy mode collects both the class and method annotation");
+    }
+
+    private static String body(ModuleDispatcherElement element, String path) {
+        MockResponse response = element.handleGet(request(path)).orElseThrow();
+        if (response.getBody() == null) {
+            return "";
+        }
+        var buffer = new Buffer();
+        try {
+            response.getBody().writeTo(buffer);
+            return buffer.readUtf8();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read response body", e);
+        }
+    }
+
+    private static RecordedRequest request(String path) {
+        return new RecordedRequest(
+                0, 0, null, Collections.emptyList(),
+                "GET", path, "HTTP/1.1",
+                HttpUrl.parse("http://localhost" + path),
+                Headers.of("Host", "localhost"),
+                ByteString.EMPTY, 0, Collections.emptyList(), null);
+    }
+}

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
@@ -15,20 +15,14 @@
  */
 package de.cuioss.test.mockwebserver.mockresponse;
 
+import de.cuioss.test.mockwebserver.dispatcher.DispatcherTestSupport;
 import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
 import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import mockwebserver3.MockResponse;
-import mockwebserver3.RecordedRequest;
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okio.Buffer;
-import okio.ByteString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -90,25 +84,7 @@ class MockResponseConfigPrecedenceTest {
     }
 
     private static String body(ModuleDispatcherElement element, String path) {
-        MockResponse response = element.handleGet(request(path)).orElseThrow();
-        if (response.getBody() == null) {
-            return "";
-        }
-        var buffer = new Buffer();
-        try {
-            response.getBody().writeTo(buffer);
-            return buffer.readUtf8();
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to read response body", e);
-        }
-    }
-
-    private static RecordedRequest request(String path) {
-        return new RecordedRequest(
-                0, 0, null, Collections.emptyList(),
-                "GET", path, "HTTP/1.1",
-                HttpUrl.parse("http://localhost" + path),
-                Headers.of("Host", "localhost"),
-                ByteString.EMPTY, 0, Collections.emptyList(), null);
+        MockResponse response = element.handleGet(DispatcherTestSupport.getRequest(path)).orElseThrow();
+        return DispatcherTestSupport.readBody(response);
     }
 }


### PR DESCRIPTION
Implements the **PR-2 `fix/dispatcher-resolution`** cluster of `doc/review-26-07-04.md`.

## Findings addressed

- **C1** — An explicitly configured `@ModuleDispatcher` that cannot be resolved (missing/failing constructor, missing/failing provider method, wrong return type) now throws `DispatcherResolutionException` instead of silently falling back to the default `/api` dispatcher.
- **C2** — Provider methods are looked up on `annotation.provider()` (or the test class when no `provider` is given) and support both `static` and instance methods.
- **C3** — A provider method returning a raw `Dispatcher` is exclusive by design; combining it with `getModuleDispatcher()` or `@MockResponseConfig` now fails loudly.
- **C4** — A method-level `@MockResponseConfig` for the same path + method as a class-level one now **overrides** it (precedence de-duplication: method > most-specific class > least-specific class) instead of triggering a conflict.
- **C5** — `getModuleDispatcher()` is resolved through the superclass hierarchy (`ReflectionUtils.findMethod`), so an inherited method from an abstract base test class is found.
- **C6** — Each `@ModuleDispatcher` annotation is resolved exactly once (single-pass resolution).
- **C11** — `BaseAllAcceptDispatcher.getOptimisticAPIDispatcher()` is now `static`, so the `@ModuleDispatcher(providerMethod = ...)` references used in tests/docs actually resolve.
- **C12** — Method-level `@ModuleDispatcher` is resolved (method takes precedence over class), and the class lookup walks the enclosing-class chain for `@Nested` tests.

## Tests

- Reworked `DispatcherResolverAdvancedTest` (H9): replaces `assertInstanceOf(CombinedDispatcher.class, …)` assertions — which could not tell a resolved dispatcher from the fallback — with **probe-request** assertions, and updated the failure cases to assert `DispatcherResolutionException`.
- Added `MockResponseConfigPrecedenceTest` covering C4 (method-level override, distinct combinations, legacy collection).
- Added a null-argument regression test for `CombinedDispatcher.dispatch` in PR-1 already; here the new branches are covered by the reworked suite.
- Stripped the OpenRewrite scanner markers (A8) from every touched file.

## Verification

`./mvnw clean install` passes (0 failures/errors) with a clean working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved test dispatcher resolution with support for more annotation-based and provider-based configurations.
  * Added shared test utilities for dispatching requests and reading responses.

* **Bug Fixes**
  * Fixed dispatcher lookup for nested, inherited, and private resolution scenarios.
  * Improved handling of conflicting or duplicate response mappings so the expected match wins consistently.

* **Tests**
  * Expanded coverage for dispatcher conflicts, fallback behavior, provider return types, and mock response precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->