### PR TITLE
fix: robust dispatch and mock-response handling (C7-C10, D1-D5)

### DIFF
--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
@@ -19,6 +19,7 @@ import de.cuioss.test.mockwebserver.EnableMockWebServer;
 import de.cuioss.tools.collect.CollectionLiterals;
 import de.cuioss.tools.logging.CuiLogger;
 import de.cuioss.tools.string.MoreStrings;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import mockwebserver3.Dispatcher;
@@ -27,6 +28,7 @@ import mockwebserver3.RecordedRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Combines multiple {@link ModuleDispatcherElement}s into a single dispatcher for handling HTTP requests
@@ -74,8 +76,16 @@ import java.util.List;
 @NoArgsConstructor
 public class CombinedDispatcher extends Dispatcher {
 
-    public static final int HTTP_CODE_NOT_FOUND = 404;
+    /**
+     * HTTP status returned for unmatched requests when teapot mode is disabled
+     * ({@link HttpServletResponse#SC_NOT_FOUND}).
+     */
+    public static final int HTTP_CODE_NOT_FOUND = HttpServletResponse.SC_NOT_FOUND;
 
+    /**
+     * HTTP 418 ("I'm a teapot") returned for unmatched requests by default. There is no
+     * {@link HttpServletResponse} constant for 418, so the literal is kept.
+     */
     public static final int HTTP_CODE_TEAPOT = 418;
 
     private static final CuiLogger LOGGER = new CuiLogger(CombinedDispatcher.class);
@@ -105,38 +115,37 @@ public class CombinedDispatcher extends Dispatcher {
     @Override
     public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
         var path = MoreStrings.nullToEmpty(request.getUrl() != null ? request.getUrl().encodedPath() : null);
-        var mapper = HttpMethodMapper.of(request);
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Processing method '%s' with path '%s'", mapper, path);
+        Optional<HttpMethodMapper> mapper = HttpMethodMapper.of(request);
+        LOGGER.debug("Processing method '%s' with path '%s'", mapper.map(HttpMethodMapper::name).orElse("UNKNOWN"), path);
 
-        List<ModuleDispatcherElement> filtered = new ArrayList<>();
-
-        for (ModuleDispatcherElement dispatcher : singleDispatcher) {
-            // Use prefix matching for all dispatchers
-            if (path.startsWith(dispatcher.getBaseUrl())) {
-                filtered.add(dispatcher);
-                LOGGER.debug("Prefix match for path '%s' with dispatcher '%s'", path, dispatcher.getClass().getSimpleName());
-            }
-
-            if (!filtered.contains(dispatcher)) {
-                /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info(dispatcher.getBaseUrl());
+        // Unknown/unsupported methods (e.g. OPTIONS, PATCH) fall through to the default response
+        if (mapper.isPresent()) {
+            for (ModuleDispatcherElement dispatcher : singleDispatcher) {
+                if (matchesBaseUrl(path, dispatcher.getBaseUrl())) {
+                    Optional<MockResponse> result = mapper.get().handleMethod(dispatcher, request);
+                    if (result.isPresent()) {
+                        return result.get();
+                    }
+                }
             }
         }
 
-        for (ModuleDispatcherElement moduleDispatcherElement : filtered) {
-            var result = mapper.handleMethod(moduleDispatcherElement, request);
-            if (result.isPresent()) {
-                return result.get();
-            }
-        }
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info(
-                "Method '%s' with path '%s' could not be processed by the configured ModuleDispatcherElements. Going to default",
-                mapper, path);
+        LOGGER.debug("Method '%s' with path '%s' was not handled by any ModuleDispatcherElement, returning default",
+                mapper.map(HttpMethodMapper::name).orElse("UNKNOWN"), path);
+        return new MockResponse.Builder().code(endWithTeapot ? HTTP_CODE_TEAPOT : HTTP_CODE_NOT_FOUND).build();
+    }
 
-        var code = HTTP_CODE_TEAPOT;
-        if (!endWithTeapot) {
-            code = HTTP_CODE_NOT_FOUND;
+    /**
+     * Matches a request path against a dispatcher base URL on segment boundaries, so that base URL
+     * {@code /api} matches {@code /api} and {@code /api/users} but not {@code /apiary}. The base URL
+     * {@code /} matches every path.
+     */
+    private static boolean matchesBaseUrl(String path, String baseUrl) {
+        if ("/".equals(baseUrl)) {
+            return true;
         }
-        return new MockResponse.Builder().code(code).build();
+        String normalized = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return path.equals(normalized) || path.startsWith(normalized + "/");
     }
 
     /**
@@ -179,6 +188,9 @@ public class CombinedDispatcher extends Dispatcher {
     /**
      * @return A new instance of the CombinedDispatcher with a default configuration providing an /api endpoint
      */
+    // The returned dispatcher is installed on the MockWebServer, which owns its lifecycle; it holds no
+    // closeable resources of its own.
+    @SuppressWarnings("java:S2095") // owolff: dispatcher is returned to and owned by the caller
     public static CombinedDispatcher createAPIDispatcher() {
         return new CombinedDispatcher(new BaseAllAcceptDispatcher("/api"));
     }

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
@@ -112,13 +112,22 @@ public enum HttpMethodMapper {
 
     /**
      * Creates an HttpMethodMapper from a RecordedRequest's method.
+     * <p>
+     * This lookup is total: an unsupported or unknown HTTP method (e.g. OPTIONS, PATCH, TRACE) yields
+     * an empty {@link Optional} rather than throwing, so callers can answer such requests with a
+     * defined fallback instead of aborting the connection.
      *
      * @param request the request containing the HTTP method, must not be null
-     * @return the corresponding HttpMethodMapper for the request's method
-     * @throws IllegalArgumentException if the method is not supported
-     * @throws NullPointerException     if request is null
+     * @return an {@link Optional} with the corresponding HttpMethodMapper, or empty if the method is
+     * not one of the supported methods
      */
-    public static HttpMethodMapper of(RecordedRequest request) {
-        return HttpMethodMapper.valueOf(MoreStrings.nullToEmpty(request.getMethod()).toUpperCase());
+    public static Optional<HttpMethodMapper> of(RecordedRequest request) {
+        String method = MoreStrings.nullToEmpty(request.getMethod()).toUpperCase();
+        for (HttpMethodMapper mapper : values()) {
+            if (mapper.name().equals(method)) {
+                return Optional.of(mapper);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfig.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfig.java
@@ -108,8 +108,13 @@ public @interface MockResponseConfig {
      * In the form of key-value pairs.
      * Mutually exclusive with {@link #textContent()} and {@link #stringContent()}.
      * <p>
-     * Format: key1=value1,key2=value2 (will be converted to {"key1":"value1","key2":"value2"})
-     * In case you need a more complex JSON structure, use {@link #stringContent()} instead.
+     * Format: key1=value1,key2=value2 (will be converted to {"key1":"value1","key2":"value2"}).
+     * String values are JSON-escaped; numeric, boolean, {@code null}, array and object literals are
+     * emitted unquoted.
+     * <p>
+     * <strong>Limitations:</strong> {@code ,} separates pairs and {@code =} separates key from value,
+     * so neither character may appear inside a key or value. For anything more complex (or values that
+     * need commas/equals signs) use {@link #stringContent()} with a literal JSON document instead.
      *
      * @return the JSON content in key-value format
      */

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElement.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElement.java
@@ -108,6 +108,17 @@ public class MockResponseConfigDispatcherElement implements ModuleDispatcherElem
         return Optional.empty();
     }
 
+    @Override
+    public Optional<MockResponse> handleHead(@NonNull RecordedRequest request) {
+        if (method == HttpMethodMapper.HEAD) {
+            // A HEAD response carries the configured status and headers but never a body.
+            var responseBuilder = new MockResponse.Builder().code(statusCode);
+            headers.forEach(responseBuilder::addHeader);
+            return Optional.of(responseBuilder.build());
+        }
+        return Optional.empty();
+    }
+
     /**
      * {@inheritDoc}
      * <p>
@@ -150,12 +161,17 @@ public class MockResponseConfigDispatcherElement implements ModuleDispatcherElem
     private Map<String, String> parseHeaders(MockResponseConfig annotation) {
         Map<String, String> headerMap = new HashMap<>();
 
-        // Add explicit headers
+        // Add explicit headers; a malformed entry is a configuration error and fails fast
         for (String header : annotation.headers()) {
-            if (!MoreStrings.isEmpty(header) && header.contains("=")) {
-                String[] parts = header.split("=", 2);
-                headerMap.put(parts[0].trim(), parts[1].trim());
+            if (MoreStrings.isEmpty(header)) {
+                continue;
             }
+            int separator = header.indexOf('=');
+            if (separator < 0) {
+                throw new IllegalArgumentException(
+                        "Malformed header entry '" + header + "'. Expected format 'name=value'.");
+            }
+            headerMap.put(header.substring(0, separator).trim(), header.substring(separator + 1).trim());
         }
 
         // Add content type if specified
@@ -288,8 +304,8 @@ public class MockResponseConfigDispatcherElement implements ModuleDispatcherElem
         String key = keyValue[0].trim();
         String value = keyValue[1].trim();
 
-        // Add quotes to key
-        jsonBuilder.append("\"").append(key).append("\":");
+        // Add quotes to the (escaped) key
+        jsonBuilder.append('"').append(escapeJson(key)).append("\":");
 
         // Add value with appropriate formatting
         appendFormattedValue(jsonBuilder, value);
@@ -305,8 +321,30 @@ public class MockResponseConfigDispatcherElement implements ModuleDispatcherElem
         if (shouldBeUnquoted(value)) {
             jsonBuilder.append(value);
         } else {
-            jsonBuilder.append("\"").append(value).append("\"");
+            jsonBuilder.append('"').append(escapeJson(value)).append('"');
         }
+    }
+
+    /**
+     * Escapes the characters that are not legal inside a JSON string literal.
+     *
+     * @param raw the raw value
+     * @return the value with {@code "}, {@code \} and control characters escaped
+     */
+    private static String escapeJson(String raw) {
+        StringBuilder escaped = new StringBuilder(raw.length());
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            switch (c) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> escaped.append(c);
+            }
+        }
+        return escaped.toString();
     }
 
     /**

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
@@ -19,7 +19,6 @@ import de.cuioss.test.mockwebserver.dispatcher.ModuleDispatcherElement;
 import de.cuioss.tools.logging.CuiLogger;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.junit.jupiter.api.Nested;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -31,12 +30,11 @@ import java.util.Map;
  * Utility class for resolving {@link MockResponseConfig} annotations from test classes
  * and converting them to {@link MockResponseConfigDispatcherElement} instances.
  * <p>
- * This class collects annotations from:
- * <ul>
- *   <li>The test class itself</li>
- *   <li>Any nested test classes (annotated with {@link Nested})</li>
- *   <li>Test methods</li>
- * </ul>
+ * Annotations are collected from the class hierarchy (the test class, its enclosing classes for
+ * {@code @Nested} tests, and its superclasses). When a test method is supplied, method-level
+ * annotations are additionally collected and take the highest precedence. In every case the result
+ * is de-duplicated by precedence so a more specific annotation overrides a less specific one that
+ * targets the same path and HTTP method.
  *
  * @author Oliver Wolff
  * @since 1.1
@@ -71,19 +69,33 @@ public class MockResponseConfigResolver {
     public List<ModuleDispatcherElement> resolveFromAnnotations(@NonNull Class<?> testClass, Method testMethod) {
         List<ModuleDispatcherElement> result = new ArrayList<>();
 
-        if (testMethod == null) {
-            // Legacy behavior: collect all annotations from the class hierarchy and all methods
-            collectFromClass(testClass, result);
-            collectFromMethods(testClass, result);
-        } else {
-            // Context-aware behavior: collect annotations relevant to the test method,
-            // de-duplicated by precedence.
-            for (MockResponseConfig annotation : collectContextAware(testMethod)) {
-                addConfigElement(annotation, result);
-            }
+        // Both modes collect class-level annotations from the class hierarchy, de-duplicated by
+        // precedence. The context-aware mode additionally gives method-level annotations the highest
+        // precedence; the legacy mode (no test method) uses class-level annotations only.
+        List<MockResponseConfig> annotations = testMethod == null
+                ? collectClassHierarchy(testClass)
+                : collectContextAware(testMethod);
+        for (MockResponseConfig annotation : annotations) {
+            addConfigElement(annotation, result);
         }
 
         return result;
+    }
+
+    /**
+     * Collects the class-level {@link MockResponseConfig} annotations from the given class and its
+     * hierarchy, de-duplicated by precedence (most-specific class first).
+     */
+    private List<MockResponseConfig> collectClassHierarchy(Class<?> testClass) {
+        List<LeveledConfig> leveled = new ArrayList<>();
+        int level = 0;
+        for (Class<?> clazz : collectContextClasses(testClass)) {
+            for (MockResponseConfig annotation : clazz.getAnnotationsByType(MockResponseConfig.class)) {
+                leveled.add(new LeveledConfig(annotation, level));
+            }
+            level++;
+        }
+        return deduplicateByPrecedence(leveled);
     }
 
     /**
@@ -151,37 +163,6 @@ public class MockResponseConfigResolver {
 
     private String key(MockResponseConfig annotation) {
         return annotation.method() + " " + annotation.path();
-    }
-
-    /**
-     * Collects {@link MockResponseConfig} annotations from the given class and its nested classes.
-     */
-    private void collectFromClass(Class<?> clazz, List<ModuleDispatcherElement> result) {
-        for (MockResponseConfig annotation : clazz.getAnnotationsByType(MockResponseConfig.class)) {
-            addConfigElement(annotation, result);
-        }
-        for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
-            if (nestedClass.isAnnotationPresent(Nested.class)) {
-                collectFromClass(nestedClass, result);
-            }
-        }
-    }
-
-    /**
-     * Collects {@link MockResponseConfig} annotations from the methods of the given class and its
-     * nested classes.
-     */
-    private void collectFromMethods(Class<?> clazz, List<ModuleDispatcherElement> result) {
-        for (Method method : clazz.getDeclaredMethods()) {
-            for (MockResponseConfig annotation : method.getAnnotationsByType(MockResponseConfig.class)) {
-                addConfigElement(annotation, result);
-            }
-        }
-        for (Class<?> nestedClass : clazz.getDeclaredClasses()) {
-            if (nestedClass.isAnnotationPresent(Nested.class)) {
-                collectFromMethods(nestedClass, result);
-            }
-        }
     }
 
     /**

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
@@ -25,7 +25,7 @@ import static jakarta.servlet.http.HttpServletResponse.*;
 class BaseAllAcceptDispatcherTest {
 
     private static final String DEFAULT_PATH = "/hello";
-    static final RecordedRequest DUMMY = CombinedDispatcherTest.createRequestFor(HttpMethodMapper.GET, "/");
+    static final RecordedRequest DUMMY = CombinedDispatcherTest.createRequest("GET", "/");
 
     @Test
     void shouldDefaultToPositiveResponse() {

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
@@ -78,9 +78,36 @@ class CombinedDispatcherTest {
         assertThrows(NullPointerException.class, () -> dispatcher.dispatch(null));
     }
 
+    @Test
+    void shouldReturnDefaultForUnsupportedMethod() {
+        // PATCH is not a supported HttpMethodMapper: it must fall through to the default response
+        // instead of throwing out of dispatch().
+        var dispatcher = new CombinedDispatcher(okDispatcher);
+        var teapot = assertDoesNotThrow(() -> dispatcher.dispatch(createRequest("PATCH", AllOkDispatcher.BASE + "/x")));
+        assertTrue(teapot.getStatus().contains(String.valueOf(HTTP_CODE_TEAPOT)),
+                "Unsupported method should yield the teapot default, was: " + teapot.getStatus());
+
+        dispatcher.endWithTeapot(false);
+        var notFound = assertDoesNotThrow(() -> dispatcher.dispatch(createRequest("OPTIONS", AllOkDispatcher.BASE + "/x")));
+        assertTrue(notFound.getStatus().contains(String.valueOf(HTTP_CODE_NOT_FOUND)),
+                "Unsupported method should yield 404 when teapot is disabled, was: " + notFound.getStatus());
+    }
+
+    @Test
+    void shouldMatchOnSegmentBoundary() {
+        var dispatcher = new CombinedDispatcher(new BaseAllAcceptDispatcher("/api"));
+        var matched = assertDoesNotThrow(() -> dispatcher.dispatch(createRequest("GET", "/api/users")));
+        assertTrue(matched.getStatus().contains(String.valueOf(SC_OK)),
+                "/api/users should match base /api, was: " + matched.getStatus());
+
+        var notMatched = assertDoesNotThrow(() -> dispatcher.dispatch(createRequest("GET", "/apiary/list")));
+        assertTrue(notMatched.getStatus().contains(String.valueOf(HTTP_CODE_TEAPOT)),
+                "/apiary should not match base /api, was: " + notMatched.getStatus());
+    }
+
     private void assertDispatchWithCode(CombinedDispatcher dispatcher, int httpCode, String urlPart) {
         for (HttpMethodMapper mapper : HttpMethodMapper.values()) {
-            var request = createRequestFor(mapper, urlPart);
+            var request = createRequest(mapper.name(), urlPart + "/someResource");
             assertDoesNotThrow(() -> {
                 var result = dispatcher.dispatch(request);
                 assertTrue(result.getStatus().contains(String.valueOf(httpCode)),
@@ -90,11 +117,10 @@ class CombinedDispatcherTest {
 
     }
 
-    static RecordedRequest createRequestFor(HttpMethodMapper mapper, String urlPart) {
-        var target = urlPart + "someResource";
+    static RecordedRequest createRequest(String method, String target) {
         return new RecordedRequest(
                 0, 0, null, Collections.emptyList(),
-                mapper.name(), target, "HTTP/1.1",
+                method, target, "HTTP/1.1",
                 HttpUrl.parse("http://localhost" + target),
                 Headers.of("key", "value", "key2", "value2"),
                 ByteString.EMPTY, 0, Collections.emptyList(), null);

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElementTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElementTest.java
@@ -224,23 +224,41 @@ class MockResponseConfigDispatcherElementTest {
         }
 
         @Test
-        @DisplayName("Should ignore malformed headers")
-        void shouldIgnoreMalformedHeaders() {
-            // Arrange
+        @DisplayName("Should reject malformed headers")
+        void shouldRejectMalformedHeaders() {
+            // Arrange - a header entry without '=' is a configuration error
             var annotation = createMockResponseWithHeaders(
                     DEFAULT_PATH, HttpMethodMapper.GET, DEFAULT_STATUS,
                     new String[]{"InvalidHeader", "X-Valid=Value"});
 
-            // Act
-            var element = new MockResponseConfigDispatcherElement(annotation);
-            RecordedRequest request = createTestRequest();
-            var response = element.handleGet(request).orElseThrow();
+            // Act & Assert
+            var exception = assertThrows(IllegalArgumentException.class,
+                    () -> new MockResponseConfigDispatcherElement(annotation));
+            assertTrue(exception.getMessage().contains("InvalidHeader"),
+                    "Exception should name the malformed header: " + exception.getMessage());
+        }
+    }
 
-            // Assert
-            assertNull(response.getHeaders().get("InvalidHeader"),
-                    "Malformed header should not be present in response");
-            assertEquals("Value", response.getHeaders().get("X-Valid"),
-                    "Valid header should be present in response");
+    @Nested
+    @DisplayName("HEAD handling tests")
+    class HeadTests {
+
+        @Test
+        @DisplayName("Should answer HEAD with status and headers but no body")
+        void shouldHandleHead() {
+            // Arrange
+            var annotation = createMockResponseWithTextContent(
+                    DEFAULT_PATH, HttpMethodMapper.HEAD, DEFAULT_STATUS, DEFAULT_TEXT_CONTENT);
+            var element = new MockResponseConfigDispatcherElement(annotation);
+
+            // Assert - a HEAD config supports HEAD only and does not answer GET
+            assertEquals(Set.of(HttpMethodMapper.HEAD), element.supportedMethods(), "Should support HEAD only");
+            assertTrue(element.handleGet(createTestRequest()).isEmpty(), "A HEAD config must not handle GET");
+
+            var response = element.handleHead(createTestRequest()).orElseThrow();
+            assertEquals("text/plain", response.getHeaders().get(CONTENT_TYPE_HEADER),
+                    "HEAD response should carry the configured headers");
+            assertNull(response.getBody(), "HEAD response must not carry a body");
         }
     }
 
@@ -278,7 +296,11 @@ class MockResponseConfigDispatcherElementTest {
                     Arguments.of("key={\"nested\":\"value\"}", "{\"key\":{\"nested\":\"value\"}}"),
                     Arguments.of("{}", "{}"),
                     Arguments.of("[]", "[]"),
-                    Arguments.of("{\"already\":\"valid\"}", "{\"already\":\"valid\"}")
+                    Arguments.of("{\"already\":\"valid\"}", "{\"already\":\"valid\"}"),
+                    // Quotes, backslashes and control characters in string values must be JSON-escaped
+                    Arguments.of("q=a\"b", "{\"q\":\"a\\\"b\"}"),
+                    Arguments.of("p=a\\b", "{\"p\":\"a\\\\b\"}"),
+                    Arguments.of("k=a\nb\tc\rd", "{\"k\":\"a\\nb\\tc\\rd\"}")
             );
         }
     }

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
@@ -75,12 +75,14 @@ class MockResponseConfigPrecedenceTest {
     }
 
     @Test
-    @DisplayName("Legacy resolution (no test method) collects class and method annotations")
-    void legacyCollectsAll() {
+    @DisplayName("Legacy resolution (no test method) collects only class-level annotations")
+    void legacyCollectsClassLevelOnly() {
         List<ModuleDispatcherElement> elements =
                 MockResponseConfigResolver.resolveFromAnnotations(DistinctFixture.class);
 
-        assertEquals(2, elements.size(), "Legacy mode collects both the class and method annotation");
+        assertEquals(1, elements.size(), "Legacy mode collects only the class-level annotation");
+        assertEquals("class", body(elements.get(0), "/class-only"),
+                "Legacy mode must resolve the class-level annotation");
     }
 
     private static String body(ModuleDispatcherElement element, String path) {

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolverTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static de.cuioss.test.mockwebserver.mockresponse.MockResponseTestUtil.DEFAULT_PATH;
@@ -75,13 +76,14 @@ class MockResponseConfigResolverTest {
     class MethodAnnotationTests {
 
         @Test
-        @DisplayName("Should resolve MockResponseConfig annotation on method")
-        void shouldResolveMethodAnnotation() {
-            // Arrange
-            Class<?> testClass = ClassWithMethodAnnotation.class;
+        @DisplayName("Should resolve MockResponseConfig annotation on the context method")
+        void shouldResolveMethodAnnotation() throws NoSuchMethodException {
+            // Arrange - method-level annotations are resolved for the current test method (context aware)
+            Method testMethod = ClassWithMethodAnnotation.class.getDeclaredMethod("testMethod");
 
             // Act
-            List<ModuleDispatcherElement> elements = MockResponseConfigResolver.resolveFromAnnotations(testClass);
+            List<ModuleDispatcherElement> elements =
+                    MockResponseConfigResolver.resolveFromAnnotations(ClassWithMethodAnnotation.class, testMethod);
 
             // Assert
             assertEquals(1, elements.size(), "Should resolve one dispatcher element");
@@ -90,6 +92,14 @@ class MockResponseConfigResolverTest {
             assertEquals("/api/method", element.getBaseUrl(),
                     "Element should have correct path");
         }
+
+        @Test
+        @DisplayName("Should not resolve method annotations without a context method (legacy mode)")
+        void shouldNotResolveMethodAnnotationInLegacyMode() {
+            List<ModuleDispatcherElement> elements =
+                    MockResponseConfigResolver.resolveFromAnnotations(ClassWithMethodAnnotation.class);
+            assertEquals(0, elements.size(), "Legacy mode resolves class-level annotations only");
+        }
     }
 
     @Nested
@@ -97,24 +107,21 @@ class MockResponseConfigResolverTest {
     class NestedClassTests {
 
         @Test
-        @DisplayName("Should resolve MockResponseConfig annotations on nested classes")
-        void shouldResolveNestedClassAnnotations() {
-            // Arrange
-            Class<?> testClass = ClassWithNestedClassTest.class;
+        @DisplayName("Should resolve annotations from the nested class and its enclosing class for a nested test method")
+        void shouldResolveNestedClassAnnotations() throws NoSuchMethodException {
+            // Arrange - resolve for a method declared in the nested class (context aware)
+            Method testMethod = ClassWithNestedClassTest.NestedTestClass.class.getDeclaredMethod("nestedTest");
 
             // Act
-            List<ModuleDispatcherElement> elements = MockResponseConfigResolver.resolveFromAnnotations(testClass);
+            List<ModuleDispatcherElement> elements =
+                    MockResponseConfigResolver.resolveFromAnnotations(ClassWithNestedClassTest.class, testMethod);
 
             // Assert
             assertEquals(2, elements.size(), SHOULD_RESOLVE_TWO_DISPATCHER_ELEMENTS);
-            assertTrue(elements.stream().allMatch(MockResponseConfigDispatcherElement.class::isInstance),
-                    "All elements should be MockResponseDispatcherElements");
-
-            // Verify paths from both parent and nested class
             assertTrue(elements.stream()
                             .map(ModuleDispatcherElement::getBaseUrl)
                             .anyMatch(DEFAULT_PATH::equals),
-                    "Should include element from parent class");
+                    "Should include element from enclosing class");
             assertTrue(elements.stream()
                             .map(ModuleDispatcherElement::getBaseUrl)
                             .anyMatch("/api/nested"::equals),
@@ -123,12 +130,13 @@ class MockResponseConfigResolverTest {
 
         @Test
         @DisplayName("Should resolve MockResponseConfig annotations on methods in nested classes")
-        void shouldResolveNestedClassMethodAnnotations() {
+        void shouldResolveNestedClassMethodAnnotations() throws NoSuchMethodException {
             // Arrange
-            Class<?> testClass = ClassWithNestedClassMethodTest.class;
+            Method testMethod = ClassWithNestedClassMethodTest.NestedTestClass.class.getDeclaredMethod("testMethod");
 
             // Act
-            List<ModuleDispatcherElement> elements = MockResponseConfigResolver.resolveFromAnnotations(testClass);
+            List<ModuleDispatcherElement> elements =
+                    MockResponseConfigResolver.resolveFromAnnotations(ClassWithNestedClassMethodTest.class, testMethod);
 
             // Assert
             assertEquals(2, elements.size(), SHOULD_RESOLVE_TWO_DISPATCHER_ELEMENTS);
@@ -184,7 +192,10 @@ class MockResponseConfigResolverTest {
         @Nested
         @MockResponseConfig(path = "/api/nested", status = DEFAULT_STATUS, textContent = "Nested content")
         class NestedTestClass {
-            // Empty nested test class
+            @SuppressWarnings("unused") // used via reflection as the context method
+            void nestedTest() {
+                // Empty nested test method
+            }
         }
     }
 


### PR DESCRIPTION
Implements the **PR-3 `fix/dispatch-and-mockresponse`** cluster of `doc/review-26-07-04.md`.

## Dispatch (`CombinedDispatcher`, `HttpMethodMapper`)

- **C7** — `HttpMethodMapper.of()` is now total (returns `Optional`); `dispatch()` answers an unsupported method (OPTIONS, PATCH, TRACE, …) with the teapot/404 default instead of throwing `IllegalArgumentException` out of the connection.
- **C8** — Removed the leftover per-request INFO logging block that also misused the dispatcher base URL as a `CuiLogger` format string.
- **C9** — Base-URL matching is on **segment boundaries**: `/api` matches `/api` and `/api/users` but not `/apiary`; `/` still matches every path.
- **C10** — `HTTP_CODE_NOT_FOUND` uses `HttpServletResponse.SC_NOT_FOUND` (418 keeps the literal, no servlet constant exists); both status constants are documented.

## Mock responses (`MockResponseConfigDispatcherElement`, `MockResponseConfigResolver`)

- **D1** — Added `handleHead`, so HEAD requests are answered with status + headers (no body) instead of falling through to 418.
- **D2** — JSON key-value conversion escapes `"`, `\` and control characters; the format limitations (`,`/`=` are separators) are documented on `jsonContentKeyValue`.
- **D3** — Malformed header entries (missing `=`) now fail fast with a clear message.
- **D4** — Legacy resolution (no test method) is aligned with context-aware resolution: class-hierarchy annotations only, de-duplicated by precedence. The dead nested/method collectors were removed.
- **D5** — Error logging passes the throwable first (already applied when the resolver was rewritten).

## Notes / tests

- Suppresses the false-positive `java:S2095` on the `CombinedDispatcher` returned by `createAPIDispatcher` (it is owned by the MockWebServer, holds no closeable resources).
- Regression tests added/updated: unsupported-method fallback, segment-boundary matching, HEAD handling, JSON escaping, malformed-header rejection, and legacy vs. context-aware resolution.
- OpenRewrite scanner markers (A8) stripped from every touched file.

`./mvnw clean install` passes with a clean working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6)_