### PR TITLE
fix: robust extension lifecycle and HTTPS handling (B1-B9, E1-E3)

### DIFF
--- a/src/main/java/de/cuioss/test/mockwebserver/CertificateResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/CertificateResolver.java
@@ -18,6 +18,8 @@ package de.cuioss.test.mockwebserver;
 import de.cuioss.test.mockwebserver.ssl.KeyMaterialUtil;
 import de.cuioss.tools.logging.CuiLogger;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.SearchOption;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 import okhttp3.tls.HandshakeCertificates;
@@ -41,7 +43,16 @@ import javax.net.ssl.SSLContext;
 class CertificateResolver {
 
     private static final CuiLogger LOGGER = new CuiLogger(CertificateResolver.class);
-    private static final String DEFAULT_PROVIDER_METHOD_NAME = "provideHandshakeCertificates";
+    /**
+     * The default provider-method name, matching {@link TestProvidedCertificate#methodName()}. This is
+     * the primary name looked up on the provider class.
+     */
+    private static final String DEFAULT_PROVIDER_METHOD_NAME = "getTestProvidedHandshakeCertificates";
+    /**
+     * Legacy provider-method name, tried only when the {@link #DEFAULT_PROVIDER_METHOD_NAME} is
+     * configured (i.e. not overridden) and not found. Kept for backwards compatibility.
+     */
+    private static final String LEGACY_PROVIDER_METHOD_NAME = "provideHandshakeCertificates";
     private static final String SELF_SIGNED_CERTIFICATES_KEY = "self-signed-certificates";
     private static final String SSL_CONTEXT_KEY = "ssl-context";
 
@@ -63,17 +74,16 @@ class CertificateResolver {
             return Optional.empty();
         }
 
-        // Check for TestProvidedCertificate annotation on the class
-        Optional<TestProvidedCertificate> classAnnotation =
-                Optional.ofNullable(testClass.get().getAnnotation(TestProvidedCertificate.class));
-
-        // Check for TestProvidedCertificate annotation on the test method
+        // Method annotation takes precedence over class annotation. The class lookup walks
+        // superclasses and enclosing classes (for @Nested tests) and honors meta-annotations,
+        // consistent with the other AnnotationSupport-based lookups in the extension.
         Optional<TestProvidedCertificate> methodAnnotation = context.getTestMethod()
-                .map(method -> method.getAnnotation(TestProvidedCertificate.class));
+                .flatMap(method -> AnnotationSupport.findAnnotation(method, TestProvidedCertificate.class));
 
-        // Method annotation takes precedence over class annotation
-        Optional<TestProvidedCertificate> annotation = methodAnnotation.isPresent() ?
-                methodAnnotation : classAnnotation;
+        Optional<TestProvidedCertificate> annotation = methodAnnotation.isPresent()
+                ? methodAnnotation
+                : AnnotationSupport.findAnnotation(testClass.get(), TestProvidedCertificate.class,
+                SearchOption.INCLUDE_ENCLOSING_CLASSES);
 
         if (annotation.isEmpty()) {
             return Optional.empty();
@@ -91,6 +101,16 @@ class CertificateResolver {
 
     /**
      * Gets HandshakeCertificates from the specified provider class.
+     * <p>
+     * Provider-method lookup order:
+     * <ol>
+     *   <li>The configured {@code methodName}.</li>
+     *   <li>Only if {@code methodName} is the {@linkplain #DEFAULT_PROVIDER_METHOD_NAME default}
+     *       and was not found: the {@linkplain #LEGACY_PROVIDER_METHOD_NAME legacy} name.</li>
+     * </ol>
+     * If an <em>explicitly configured</em> (non-default) method name does not resolve, this fails
+     * fast with an {@link IllegalStateException} rather than silently falling back to self-signed
+     * certificates — a typo in {@code methodName()} must not silently change the certificate source.
      *
      * @param providerClass the class that provides certificates
      * @param methodName    the name of the method that provides certificates
@@ -100,17 +120,24 @@ class CertificateResolver {
     @SuppressWarnings("java:S3655")
     // owolff: False positive: context.getTestClass().isPresent() is called before
     Optional<HandshakeCertificates> getCertificatesFromProvider(Class<?> providerClass, String methodName, ExtensionContext context) {
-        try {
-            // Look for the certificate method in the provider class
-            Optional<Method> method = ReflectionUtils.findMethod(providerClass, methodName);
-            if (method.isEmpty() && !DEFAULT_PROVIDER_METHOD_NAME.equals(methodName)) {
-                // Try the default provider method name as a fallback
-                method = ReflectionUtils.findMethod(providerClass, DEFAULT_PROVIDER_METHOD_NAME);
+        // Look for the certificate method in the provider class
+        Optional<Method> method = ReflectionUtils.findMethod(providerClass, methodName);
+        if (method.isEmpty()) {
+            if (DEFAULT_PROVIDER_METHOD_NAME.equals(methodName)) {
+                // Default was requested (i.e. not overridden): fall back to the legacy name, then
+                // to self-signed certificates if neither resolves.
+                method = ReflectionUtils.findMethod(providerClass, LEGACY_PROVIDER_METHOD_NAME);
+                if (method.isEmpty()) {
+                    return Optional.empty();
+                }
+            } else {
+                // An explicit method name was configured but does not exist: fail fast.
+                throw new IllegalStateException("Configured @TestProvidedCertificate method '" + methodName +
+                        "' not found on provider class " + providerClass.getName());
             }
-            if (method.isEmpty()) {
-                return Optional.empty();
-            }
+        }
 
+        try {
             // Create an instance of the provider class if it's the test class
             Object providerInstance = null;
 
@@ -130,7 +157,7 @@ class CertificateResolver {
             }
 
             return Optional.empty();
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Error resolving HandshakeCertificates from provider " + providerClass.getName(), e);
         }
@@ -146,7 +173,7 @@ class CertificateResolver {
     Object createProviderInstance(Class<?> providerClass) {
         try {
             return ReflectionUtils.newInstance(providerClass);
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Could not create instance of provider class " + providerClass.getName(), e);
         }
@@ -203,7 +230,7 @@ class CertificateResolver {
                     config.getKeyAlgorithm(), config.getCertificateDuration());
 
             return Optional.of(certificates);
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
             LOGGER.error(e, "Failed to create self-signed certificates");
             return Optional.empty();
         }
@@ -254,14 +281,15 @@ class CertificateResolver {
         try {
             SSLContext sslContext = KeyMaterialUtil.createSslContext(handshakeCertificates);
 
-            // Store the SSLContext in the context store for parameter resolution
-            ExtensionContext rootContext = getRootContext(context);
-            rootContext.getStore(NAMESPACE).put(SSL_CONTEXT_KEY, sslContext);
+            // Store the SSLContext in the class-level store so it is scoped to the current test
+            // class: a subsequently-executed class without useHttps must not receive this context,
+            // and parallel classes with different certificates must not race on a shared root key.
+            getClassContext(context).getStore(NAMESPACE).put(SSL_CONTEXT_KEY, sslContext);
 
             LOGGER.debug("Stored SSLContext for parameter resolution");
 
             return sslContext;
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
             String errorMessage = "Failed to create or store SSLContext";
             LOGGER.error(e, errorMessage);
             throw new IllegalStateException(errorMessage, e);
@@ -275,11 +303,8 @@ class CertificateResolver {
      * @return the SSLContext for HTTPS configuration
      */
     public Optional<SSLContext> getSSLContext(ExtensionContext context) {
-        // Get the root context to access the store
-        ExtensionContext rootContext = getRootContext(context);
-
-        // Try to get the SSLContext from the store
-        return Optional.ofNullable(rootContext.getStore(NAMESPACE)
+        // The SSLContext is stored in the class-level store (see createAndStoreSSLContext).
+        return Optional.ofNullable(getClassContext(context).getStore(NAMESPACE)
                 .get(SSL_CONTEXT_KEY, SSLContext.class));
     }
 
@@ -297,5 +322,19 @@ class CertificateResolver {
             current = current.getParent().get();
         }
         return current;
+    }
+
+    /**
+     * Returns the class-level context for the current (method-level) context.
+     * <p>
+     * The extension resolves certificates and parameters from a method-level context whose parent is
+     * the (possibly {@link org.junit.jupiter.api.Nested @Nested}) test-class context. Scoping the
+     * {@code SSLContext} there keeps it isolated per test class.
+     *
+     * @param context the current extension context
+     * @return the class-level context, or {@code context} itself if it has no parent
+     */
+    ExtensionContext getClassContext(ExtensionContext context) {
+        return context.getParent().orElse(context);
     }
 }

--- a/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
@@ -32,6 +32,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 import okhttp3.tls.HandshakeCertificates;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -152,6 +153,11 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
     public static final Namespace NAMESPACE = Namespace.create(MockWebServerExtension.class);
 
     /**
+     * Key under which the {@link MockWebServer} is stored in the extension context.
+     */
+    private static final String SERVER_KEY = MockWebServer.class.getName();
+
+    /**
      * Maps parameter types to resolver functions.
      */
     private final Map<Class<?>, Function<MockWebServer, Object>> parameterResolvers = Map.of(
@@ -184,10 +190,10 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
             configureDispatcher(server, testInstance, context);
 
 
-            if (!config.manualStart()) {
-                startServer(server);
+            if (config.manualStart()) {
+                LOGGER.debug("Manual start requested, MockWebServer not started");
             } else {
-                ensureServerNotStarted(server);
+                startServer(server);
             }
 
             // Store the server in context - it will be properly closed in afterEach
@@ -195,21 +201,19 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
             // We've successfully stored the server in context, so don't close it in the finally block
             server = null;
             LOGGER.debug("MockWebServer setup completed successfully");
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            if (e instanceof IllegalStateException || e instanceof DispatcherResolutionException) {
-                LOGGER.error(e, "Critical error during MockWebServer setup: %s", e.getMessage());
-                throw e; // Propagate these exceptions directly
-            } else {
-                LOGGER.error(e, "Unexpected error during MockWebServer setup");
-            }
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+            // Never continue silently: a swallowed setup failure surfaces later as a misleading
+            // "No MockWebServer instance available" and hides the real cause.
+            LOGGER.error(e, "Error during MockWebServer setup: %s", e.getMessage());
+            throw e;
         } finally {
             // Close the server if something went wrong and we didn't store it in context
             if (server != null) {
                 try {
                     server.close();
-                    LOGGER.info("Shutdown server due to exception during setup");
-                } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception closeEx) {
-                    LOGGER.warn("Failed to shutdown server during exception handling: %s", closeEx.getMessage());
+                    LOGGER.debug("Closed MockWebServer after a failed setup");
+                } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException closeEx) {
+                    LOGGER.warn("Failed to close MockWebServer during exception handling: %s", closeEx.getMessage());
                 }
             }
         }
@@ -224,30 +228,12 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
     private void startServer(MockWebServer server) {
         try {
             server.start();
-            LOGGER.info("Started MockWebServer at %s", server.url("/"));
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            LOGGER.debug("Started MockWebServer at %s", server.url("/"));
+        } catch (IOException e) {
             String errorMessage = "Failed to start MockWebServer";
             LOGGER.error(e, errorMessage);
             throw new IllegalStateException(errorMessage, e);
         }
-    }
-
-    /**
-     * Ensures the server is not started when manual start is requested.
-     *
-     * @param server the server to check
-     */
-    private void ensureServerNotStarted(MockWebServer server) {
-        // When manual start is requested, ensure the server is not started
-        if (server.getStarted()) {
-            try {
-                server.close();
-                LOGGER.info("Shutdown server to enforce manual start configuration");
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-                LOGGER.warn("Failed to shutdown server for manual start: %s", e.getMessage());
-            }
-        }
-        LOGGER.info("Manual start requested, server not started");
     }
 
     /**
@@ -291,7 +277,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
      * @throws IllegalStateException if certificate material cannot be obtained
      */
     private void configureHttps(MockWebServer server, ExtensionContext context, MockServerConfig config) {
-        LOGGER.info("Configuring HTTPS for MockWebServer");
+        LOGGER.debug("Configuring HTTPS for MockWebServer");
 
         // Use the CertificateResolver to get HandshakeCertificates
         CertificateResolver certificateResolver = new CertificateResolver();
@@ -301,11 +287,11 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
             try {
                 // Apply certificates to server
                 server.useHttps(handshakeCertificates.get().sslSocketFactory());
-                LOGGER.info("HTTPS configured for MockWebServer");
+                LOGGER.debug("HTTPS configured for MockWebServer");
 
                 // Store certificates for parameter resolution
                 certificateResolver.createAndStoreSSLContext(context, handshakeCertificates.get());
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
                 String errorMessage = "Failed to configure HTTPS with available certificates";
                 LOGGER.error(e, errorMessage);
                 throw new IllegalStateException(errorMessage, e);
@@ -329,18 +315,18 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
      * @throws DispatcherResolutionException if there is an error resolving the dispatcher
      */
     private void configureDispatcher(MockWebServer server, Object testInstance, ExtensionContext context) {
-        LOGGER.info("Configuring dispatcher for test class: %s", testInstance.getClass().getName());
+        LOGGER.debug("Configuring dispatcher for test class: %s", testInstance.getClass().getName());
 
         // Extract the current test method from the context
         Method testMethod = context.getTestMethod().orElse(null);
         if (testMethod != null) {
-            LOGGER.info("Using context-aware resolution for test method: %s", testMethod.getName());
+            LOGGER.debug("Using context-aware resolution for test method: %s", testMethod.getName());
         }
 
         Dispatcher dispatcher = dispatcherResolver.resolveDispatcher(
                 testInstance.getClass(), testInstance, testMethod);
         server.setDispatcher(dispatcher);
-        LOGGER.info("Configured dispatcher: %s", dispatcher.getClass().getName());
+        LOGGER.debug("Configured dispatcher: %s", dispatcher.getClass().getName());
     }
 
 
@@ -351,13 +337,13 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
             var server = optionalMockWebServer.get();
             try {
                 if (server.getStarted()) {
-                    LOGGER.info("Shutting down MockWebServer at port %s", server.getPort());
+                    LOGGER.debug("Shutting down MockWebServer at port %s", server.getPort());
                     server.close();
                     LOGGER.debug("MockWebServer successfully shut down");
                 } else {
                     LOGGER.debug("Server was not started, no shutdown needed");
                 }
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
                 LOGGER.error(e, "Failed to shutdown MockWebServer");
                 throw new IllegalStateException("Failed to properly shutdown MockWebServer", e);
             } finally {
@@ -373,12 +359,8 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
      * @param context the extension context
      */
     private void remove(ExtensionContext context) {
-        try {
-            context.getStore(NAMESPACE).remove(context.getRequiredTestMethod());
-            LOGGER.debug("Removed MockWebServer from context");
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            LOGGER.warn("Failed to remove MockWebServer from context: %s", e.getMessage());
-        }
+        context.getStore(NAMESPACE).remove(SERVER_KEY);
+        LOGGER.debug("Removed MockWebServer from context");
     }
 
     /**
@@ -388,7 +370,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
      * @param context       the extension context
      */
     private static void put(MockWebServer mockWebServer, ExtensionContext context) {
-        context.getStore(NAMESPACE).put(MockWebServer.class.getName(), mockWebServer);
+        context.getStore(NAMESPACE).put(SERVER_KEY, mockWebServer);
     }
 
     /**
@@ -398,28 +380,33 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
      * @return an Optional containing the MockWebServer instance if present
      */
     private Optional<MockWebServer> get(ExtensionContext context) {
-        return Optional.ofNullable((MockWebServer) context.getStore(NAMESPACE).get(MockWebServer.class.getName()));
+        return Optional.ofNullable((MockWebServer) context.getStore(NAMESPACE).get(SERVER_KEY));
     }
 
 
     /**
-     * Extracts the class hierarchy for the given test instance.
+     * Extracts the class hierarchy for the given test instance, ordered most-specific first: the test
+     * class and its superclasses, then each enclosing class (for {@code @Nested} tests) and their
+     * superclasses. This ordering lets a {@code @Nested} class's own {@link EnableMockWebServer}
+     * annotation win over one on an enclosing class.
      *
      * @param testInstance the test instance
-     * @return a list of classes in the hierarchy
+     * @return a list of classes in the hierarchy, most-specific first
      */
     private List<Class<?>> extractClassHierarchy(Object testInstance) {
         List<Class<?>> classHierarchy = new ArrayList<>();
-        Class<?> testClass = testInstance.getClass();
 
-        // Add enclosing classes if present
-        Class<?> enclosingClass = testClass.getEnclosingClass();
-        if (enclosingClass != null) {
-            addClassHierarchy(enclosingClass, classHierarchy);
+        Class<?> enclosing = testInstance.getClass();
+        while (enclosing != null) {
+            Class<?> current = enclosing;
+            while (current != null && !Object.class.equals(current)) {
+                if (!classHierarchy.contains(current)) {
+                    classHierarchy.add(current);
+                }
+                current = current.getSuperclass();
+            }
+            enclosing = enclosing.getEnclosingClass();
         }
-
-        // Add the class hierarchy of the test class itself
-        addClassHierarchy(testClass, classHierarchy);
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Extracted class hierarchy from %s, resulting in:\n\t-%s",
@@ -428,20 +415,6 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
         }
 
         return classHierarchy;
-    }
-
-    /**
-     * Adds a class and its superclasses to the hierarchy list.
-     *
-     * @param clazz     the starting class
-     * @param hierarchy the list to add classes to
-     */
-    private void addClassHierarchy(Class<?> clazz, List<Class<?>> hierarchy) {
-        Class<?> current = clazz;
-        while (current != null && !Object.class.equals(current)) {
-            hierarchy.add(current);
-            current = current.getSuperclass();
-        }
     }
 
     @Override
@@ -490,28 +463,17 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
 
 
     /**
-     * Creates a URIBuilder initialized with the server's base URL.
+     * Creates a URIBuilder bound to the server's base URL.
+     * <p>
+     * The base URL is resolved lazily, at {@link URIBuilder#build()} time, from the current server
+     * state. This makes injection work with {@code manualStart=true}: the returned builder resolves
+     * correctly once the test has started the server.
      *
      * @param server the MockWebServer instance
      * @return a URIBuilder for the server
-     * @throws ParameterResolutionException if URL conversion fails
      */
     private URIBuilder resolveUrlBuilderParameter(MockWebServer server) {
-        try {
-            // Check if the server is already started
-            if (server.getStarted()) {
-                return URIBuilder.from(server.url("/").url());
-            } else {
-                // For manual start configuration, create a placeholder URIBuilder
-                // that will be updated when the server is actually started
-                LOGGER.debug("Creating placeholder URIBuilder for non-started server");
-                return URIBuilder.placeholder();
-            }
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            LOGGER.error(e, "Failed to create URIBuilder from MockWebServer URL");
-            throw new ParameterResolutionException(
-                    "Failed to create URIBuilder from MockWebServer URL: " + e.getMessage(), e);
-        }
+        return URIBuilder.from(() -> server.url("/").url());
     }
 
     /**

--- a/src/main/java/de/cuioss/test/mockwebserver/TestProvidedCertificate.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/TestProvidedCertificate.java
@@ -34,6 +34,16 @@ import java.lang.annotation.Target;
  *   <li>In a separate provider class specified by the {@link #providerClass()} attribute</li>
  * </ol>
  * <p>
+ * <strong>Provider-method lookup order.</strong> The extension resolves the provider method on
+ * the configured class as follows:
+ * <ol>
+ *   <li>The method named by {@link #methodName()} (default {@code getTestProvidedHandshakeCertificates}).</li>
+ *   <li>Only when {@link #methodName()} is left at its default and that method is absent, the legacy
+ *       name {@code provideHandshakeCertificates} is tried for backwards compatibility.</li>
+ * </ol>
+ * If an <em>explicitly configured</em> {@link #methodName()} does not resolve, resolution fails fast
+ * rather than silently falling back — a typo must not change the certificate source unnoticed.
+ * <p>
  * This annotation provides a clean way to specify custom certificate material
  * for HTTPS testing.
  * <p>
@@ -103,9 +113,10 @@ public @interface TestProvidedCertificate {
 
     /**
      * Optional class that provides the HandshakeCertificates.
-     * The class must have a method that returns {@code okhttp3.tls.HandshakeCertificates}.
-     * By default, the method name is "provideHandshakeCertificates", but this can be
-     * overridden using the {@link #methodName()} attribute.
+     * The class must have a method that returns {@code okhttp3.tls.HandshakeCertificates}, resolved
+     * according to the lookup order documented on this annotation (default
+     * {@code getTestProvidedHandshakeCertificates}, then the legacy {@code provideHandshakeCertificates}).
+     * The method name can be overridden using the {@link #methodName()} attribute.
      * This can be an instance method or a static method.
      *
      * @return the class that provides the certificates

--- a/src/main/java/de/cuioss/test/mockwebserver/URIBuilder.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/URIBuilder.java
@@ -18,12 +18,14 @@ package de.cuioss.test.mockwebserver;
 import de.cuioss.tools.net.UrlHelper;
 import lombok.NonNull;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -53,25 +55,34 @@ import java.util.stream.Collectors;
  */
 public class URIBuilder {
 
-    private final URL baseUrl;
+    private URL baseUrl;
+    private final Supplier<URL> baseUrlSupplier;
     private final List<String> pathSegments = new ArrayList<>();
     private final Map<String, List<String>> queryParameters = new LinkedHashMap<>();
     private final boolean placeholder;
 
     private URIBuilder(URL baseUrl) {
         this.baseUrl = baseUrl;
+        this.baseUrlSupplier = null;
+        this.placeholder = false;
+    }
+
+    private URIBuilder(Supplier<URL> baseUrlSupplier) {
+        this.baseUrl = null;
+        this.baseUrlSupplier = baseUrlSupplier;
         this.placeholder = false;
     }
 
     /**
      * Creates a placeholder URIBuilder that can be used when the server is not yet started.
      * This is useful for manual server start configurations.
-     * 
+     *
      * @implNote When using a placeholder URIBuilder, you must start the server before calling
      * {@link #build()} or any other method that requires the base URL.
      */
     private URIBuilder() {
         this.baseUrl = null;
+        this.baseUrlSupplier = null;
         this.placeholder = true;
     }
 
@@ -86,6 +97,20 @@ public class URIBuilder {
     }
 
     /**
+     * Creates a new builder whose base URL is resolved lazily, on first use.
+     * <p>
+     * This supports servers that are started after parameter injection (e.g.
+     * {@code @EnableMockWebServer(manualStart = true)}): the base URL is obtained from the supplier
+     * the first time {@link #build()} (or another URL-dependent method) is called.
+     *
+     * @param baseUrlSupplier supplies the base URL on demand, must not be null
+     * @return a new builder instance
+     */
+    public static URIBuilder from(@NonNull Supplier<URL> baseUrlSupplier) {
+        return new URIBuilder(baseUrlSupplier);
+    }
+
+    /**
      * Creates a new builder with the given base URI.
      * This method converts the URI to a URL internally.
      *
@@ -96,9 +121,21 @@ public class URIBuilder {
     public static URIBuilder from(@NonNull URI baseUri) {
         try {
             return new URIBuilder(baseUri.toURL());
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Could not convert URI to URL: " + baseUri, e);
         }
+    }
+
+    /**
+     * Resolves the base URL, invoking the supplier on first use for lazily-bound builders.
+     *
+     * @return the resolved base URL, or {@code null} for a placeholder builder
+     */
+    private URL resolveBaseUrl() {
+        if (baseUrl == null && baseUrlSupplier != null) {
+            baseUrl = baseUrlSupplier.get();
+        }
+        return baseUrl;
     }
 
     /**
@@ -197,21 +234,21 @@ public class URIBuilder {
             }
         }
 
-        if (baseUrl == null) {
+        if (resolveBaseUrl() == null) {
             throw new IllegalStateException("Cannot build URI with null baseUrl. This might indicate an incorrectly initialized URIBuilder.");
         }
     }
 
     /**
      * Builds the URI with all configured path segments and query parameters.
-     * 
+     *
      * @return the constructed URI
      * @throws IllegalStateException if this is a placeholder URIBuilder or if baseUrl is null
      */
     public URI build() {
         validateBuilderState(false);
 
-        String baseUrlString = baseUrl.toString();
+        String baseUrlString = resolveBaseUrl().toString();
         StringBuilder uriBuilder = new StringBuilder();
 
         // Normalize base URL by removing trailing slash
@@ -262,10 +299,11 @@ public class URIBuilder {
         if (placeholder) {
             return "/";
         }
-        if (baseUrl == null) {
+        URL resolved = resolveBaseUrl();
+        if (resolved == null) {
             throw new IllegalStateException("Cannot access path with null baseUrl. This might indicate an incorrectly initialized URIBuilder.");
         }
-        return baseUrl.getPath();
+        return resolved.getPath();
     }
 
     /**
@@ -277,10 +315,11 @@ public class URIBuilder {
         if (placeholder) {
             return "http";
         }
-        if (baseUrl == null) {
+        URL resolved = resolveBaseUrl();
+        if (resolved == null) {
             throw new IllegalStateException("Cannot access scheme with null baseUrl. This might indicate an incorrectly initialized URIBuilder.");
         }
-        return baseUrl.getProtocol();
+        return resolved.getProtocol();
     }
 
     /**
@@ -292,10 +331,11 @@ public class URIBuilder {
         if (placeholder) {
             return -1; // -1 indicates no port is explicitly set
         }
-        if (baseUrl == null) {
+        URL resolved = resolveBaseUrl();
+        if (resolved == null) {
             throw new IllegalStateException("Cannot access port with null baseUrl. This might indicate an incorrectly initialized URIBuilder.");
         }
-        return baseUrl.getPort();
+        return resolved.getPort();
     }
 
     /**

--- a/src/main/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtil.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtil.java
@@ -24,8 +24,8 @@ import okhttp3.tls.HeldCertificate;
 
 import java.security.KeyManagementException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -87,35 +87,60 @@ public class KeyMaterialUtil {
             Instant now = Instant.now();
             Instant validUntil = now.plus(durationDays, ChronoUnit.DAYS);
 
-            // Create the certificate
-            var heldCertificate = new HeldCertificate.Builder()
+            // Create the certificate honoring the requested key algorithm
+            HeldCertificate.Builder builder = new HeldCertificate.Builder()
                     .commonName("MockWebServer")
                     .addSubjectAlternativeName("localhost")
-                    .validityInterval(now.toEpochMilli(), validUntil.toEpochMilli())
-                    .rsa2048()  // Default to RSA 2048
-                    .build();
+                    .validityInterval(now.toEpochMilli(), validUntil.toEpochMilli());
+            applyKeyAlgorithm(builder, keyAlgorithm);
+            var heldCertificate = builder.build();
 
             // Create HandshakeCertificates that includes the certificate as both server and trusted cert
             return new HandshakeCertificates.Builder()
                     .heldCertificate(heldCertificate)
                     .addTrustedCertificate(heldCertificate.certificate())
                     .build();
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
             throw new IllegalStateException("Failed to create self-signed HandshakeCertificates", e);
+        }
+    }
+
+    /**
+     * Configures the key algorithm on the given certificate builder.
+     * <p>
+     * Elliptic-curve algorithms map to {@code ecdsa256()}; every other value (including RSA variants
+     * and {@code null}) maps to {@code rsa2048()}, the default.
+     *
+     * @param builder      the certificate builder to configure
+     * @param keyAlgorithm the requested algorithm, may be {@code null}
+     */
+    private static void applyKeyAlgorithm(HeldCertificate.Builder builder, KeyAlgorithm keyAlgorithm) {
+        if (keyAlgorithm != null && keyAlgorithm.name().startsWith("ECDSA")) {
+            builder.ecdsa256();
+        } else {
+            builder.rsa2048();
         }
     }
 
 
     /**
-     * Converts an SSLContext to HandshakeCertificates.
-     * This method creates a HandshakeCertificates instance from an existing SSLContext,
-     * which is useful when you have an SSLContext and need to use it with MockWebServer.
+     * Generates fresh {@link HandshakeCertificates} backed by a newly created self-signed certificate,
+     * combined with the JVM's system trust roots.
+     * <p>
+     * <strong>This method does not derive any key material from {@code sslContext}.</strong> Private
+     * keys and certificates cannot be extracted from an initialized {@link SSLContext}, so the input is
+     * used only as a non-null guard; the returned certificates are unrelated to it. The parameter is
+     * retained for source compatibility.
      *
-     * @param sslContext the SSLContext to convert
-     * @return HandshakeCertificates configured from the provided SSLContext
+     * @param sslContext must not be {@code null}; otherwise unused
+     * @return freshly generated self-signed {@code HandshakeCertificates} plus system trust roots
      * @throws IllegalArgumentException if the SSLContext is null
-     * @throws IllegalStateException    if the conversion fails
+     * @throws IllegalStateException    if certificate generation fails
+     * @deprecated cannot convert an existing {@link SSLContext}; use
+     * {@link #createSelfSignedHandshakeCertificates(int, KeyAlgorithm)} to generate test material.
+     * Scheduled for removal in the next major release.
      */
+    @Deprecated(forRemoval = true)
     public static HandshakeCertificates convertToHandshakeCertificates(SSLContext sslContext) {
         LOGGER.debug("Converting SSLContext to HandshakeCertificates");
 
@@ -151,7 +176,7 @@ public class KeyMaterialUtil {
             }
 
             return builder.build();
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } catch (NoSuchAlgorithmException | KeyStoreException e) {
             throw new IllegalStateException("Failed to convert SSLContext to HandshakeCertificates", e);
         }
     }
@@ -178,15 +203,11 @@ public class KeyMaterialUtil {
             // Create and initialize the SSLContext with the TrustManager
             SSLContext sslContext = SSLContext.getInstance("TLS");
 
-            // Use a properly seeded SecureRandom instance
-            // For testing purposes only - not for production use
-            SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
-            secureRandom.setSeed(System.currentTimeMillis());
-
+            // Pass null so the provider supplies its own securely-seeded SecureRandom
             sslContext.init(
                     null, // No need for KeyManager as we're configuring client-side trust
                     new TrustManager[]{trustManager},
-                    secureRandom
+                    null
             );
 
             return sslContext;

--- a/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTest.java
@@ -194,7 +194,7 @@ class CertificateResolverTest {
 
 
         @ParameterizedTest
-        @ValueSource(classes = {NonAnnotatedTestClass.class, TestClassWithNonExistentMethod.class, TestClassWithNonExistentProvider.class})
+        @ValueSource(classes = {NonAnnotatedTestClass.class, TestClassWithNonExistentProvider.class})
         @DisplayName("Should return empty optional for invalid configurations")
         void shouldReturnEmptyOptionalForInvalidConfigurations(Class<?> testClass) {
             // Arrange
@@ -205,6 +205,20 @@ class CertificateResolverTest {
 
             // Assert
             assertFalse(result.isPresent(), "Should return empty optional for " + testClass.getSimpleName());
+        }
+
+        @Test
+        @DisplayName("Should fail fast when an explicitly configured method name does not exist")
+        void shouldFailFastForExplicitNonExistentMethod() {
+            // Arrange
+            ExtensionContext mockContext = createMockContext(TestClassWithNonExistentMethod.class);
+
+            // Act + Assert: a typo in an explicit methodName() must not silently fall back to self-signed
+            var exception = assertThrows(IllegalStateException.class,
+                    () -> resolver.determineTestProvidedHandshakeCertificates(mockContext),
+                    "Explicitly configured missing method should fail fast");
+            assertTrue(exception.getMessage().contains("nonExistentMethod"),
+                    "Message should name the missing method");
         }
 
         @Test
@@ -315,6 +329,33 @@ class CertificateResolverTest {
             }
             // This class intentionally has no provider method to test error handling
         }
+
+        @Test
+        @DisplayName("Should wrap a provider method that throws in an IllegalStateException")
+        void shouldWrapProviderMethodFailure() {
+            // Arrange
+            ExtensionContext mockContext = createMockContext(TestClassWithThrowingProvider.class);
+
+            // Act + Assert
+            var exception = assertThrows(IllegalStateException.class,
+                    () -> resolver.determineTestProvidedHandshakeCertificates(mockContext),
+                    "A throwing provider method should surface as IllegalStateException");
+            assertTrue(exception.getMessage().contains(TestClassWithThrowingProvider.class.getName()),
+                    "Message should name the provider class");
+        }
+
+        @TestProvidedCertificate(methodName = "boom")
+        static class TestClassWithThrowingProvider {
+            /**
+             * Provider method that always fails, to verify error propagation.
+             *
+             * @return never returns
+             */
+            @SuppressWarnings("unused") // implicitly called by the resolver
+            public static HandshakeCertificates boom() {
+                throw new IllegalArgumentException("provider failure");
+            }
+        }
     }
 
     @Nested
@@ -417,6 +458,46 @@ class CertificateResolverTest {
             assertTrue(retrievedContextOptional.isPresent(), "SSLContext should be retrieved from context");
             SSLContext retrievedContext = retrievedContextOptional.get();
             assertSame(sslContext, retrievedContext, "Should return the same SSLContext instance from context");
+        }
+
+        @Test
+        @DisplayName("Should store the SSLContext in the class-level (parent) store, not globally")
+        void shouldStoreSslContextInClassLevelStore() {
+            // Arrange: a method-level context whose parent is the class-level context.
+            // The SSLContext must be scoped to the class store so a subsequent non-HTTPS class
+            // cannot receive a stale context.
+            final SSLContext[] classStored = new SSLContext[1];
+
+            ExtensionContext.Store classStore = EasyMock.createMock(ExtensionContext.Store.class);
+            classStore.put(EasyMock.eq(SSL_CONTEXT_KEY), EasyMock.anyObject(SSLContext.class));
+            EasyMock.expectLastCall().andAnswer(() -> {
+                classStored[0] = (SSLContext) EasyMock.getCurrentArguments()[1];
+                return null;
+            }).anyTimes();
+            EasyMock.expect(classStore.get(SSL_CONTEXT_KEY, SSLContext.class))
+                    .andAnswer(() -> classStored[0]).anyTimes();
+
+            ExtensionContext classContext = EasyMock.createMock(ExtensionContext.class);
+            EasyMock.expect(classContext.getStore(CertificateResolver.NAMESPACE)).andReturn(classStore).anyTimes();
+
+            ExtensionContext methodContext = EasyMock.createMock(ExtensionContext.class);
+            EasyMock.expect(methodContext.getParent()).andReturn(Optional.of(classContext)).anyTimes();
+
+            EasyMock.replay(classStore, classContext, methodContext);
+
+            HandshakeCertificates certificates =
+                    KeyMaterialUtil.createSelfSignedHandshakeCertificates(1, KeyAlgorithm.RSA_2048);
+
+            // Act
+            SSLContext created = resolver.createAndStoreSSLContext(methodContext, certificates);
+            Optional<SSLContext> retrieved = resolver.getSSLContext(methodContext);
+
+            // Assert: it went to the class store and is read back from there
+            assertSame(created, classStored[0], "SSLContext should be stored in the class-level store");
+            assertTrue(retrieved.isPresent(), "SSLContext should be retrieved from the class-level store");
+            assertSame(created, retrieved.get(), "Should return the SSLContext from the class-level store");
+
+            EasyMock.verify(classStore, classContext, methodContext);
         }
     }
 }

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionErrorHandlingTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionErrorHandlingTest.java
@@ -17,11 +17,11 @@ package de.cuioss.test.mockwebserver;
 
 import de.cuioss.test.mockwebserver.dispatcher.CombinedDispatcher;
 import de.cuioss.tools.logging.CuiLogger;
+import lombok.NonNull;
 import mockwebserver3.Dispatcher;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
-import lombok.NonNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -199,7 +199,8 @@ class MockWebServerExtensionErrorHandlingTest {
 
         /**
          * Nested class with a different annotation configuration.
-         * The parent class annotation should take precedence.
+         * The most-specific annotation (this nested class's own) takes precedence over the
+         * enclosing class's annotation.
          */
         @Nested
         @DisplayName("Nested With Different Config")
@@ -207,15 +208,14 @@ class MockWebServerExtensionErrorHandlingTest {
         class NestedWithDifferentConfig {
 
             @Test
-            @DisplayName("Should use parent class annotation")
-            void shouldUseParentClassAnnotation(MockWebServer server, SSLContext sslContext) {
+            @DisplayName("Should use this class's own annotation over the enclosing one")
+            void shouldUseMostSpecificAnnotation(MockWebServer server) {
                 assertNotNull(server, SERVER_SHOULD_BE_INJECTED);
                 assertTrue(server.getStarted(), SERVER_SHOULD_BE_STARTED);
-                assertNotNull(sslContext, SSL_CONTEXT_SHOULD_BE_INJECTED);
 
-                // Even though this class has useHttps=false, it should inherit useHttps=true from parent
-                assertTrue(server.url("/").url().toString().startsWith("https://"),
-                        "Server URL should use HTTPS scheme from parent config");
+                // This class declares useHttps=false, which must win over the enclosing useHttps=true.
+                assertTrue(server.url("/").url().toString().startsWith("http://"),
+                        "Server URL should use HTTP scheme from this class's own config");
             }
         }
     }
@@ -322,7 +322,7 @@ class MockWebServerExtensionErrorHandlingTest {
                     HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
                     assertEquals(200, response.statusCode(), "Original server should still work");
                 });
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (Exception e) {
                 LOGGER.error(e, "Error in second server test");
             }
         }

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerManualStartTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerManualStartTest.java
@@ -88,7 +88,8 @@ class MockWebServerManualStartTest {
                 LOGGER.info("Successfully received response from manually started server: " + response.body());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
             }
         });
         // end::manual-start-test-response[]
@@ -116,10 +117,38 @@ class MockWebServerManualStartTest {
                 if (server.getStarted()) {
                     server.close();
                 }
-            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (Exception e) {
                 // Ignore shutdown errors in tests
             }
         }
+    }
+
+    @Test
+    @DisplayName("Injected URIBuilder should bind lazily and work after manual start")
+    void shouldUseInjectedUriBuilderAfterManualStart(MockWebServer server, URIBuilder injectedUriBuilder) {
+        assertNotNull(server, SERVER_SHOULD_BE_INJECTED);
+        assertNotNull(injectedUriBuilder, "URIBuilder should be injected");
+        assertFalse(server.getStarted(), SERVER_SHOULD_NOT_BE_STARTED);
+
+        // Start the server manually; the injected builder must resolve the base URL lazily at build() time
+        assertDoesNotThrow(() -> server.start());
+        assertTrue(server.getStarted(), SERVER_SHOULD_BE_STARTED);
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(injectedUriBuilder.addPathSegments("api", "test").build())
+                .GET()
+                .build();
+
+        assertDoesNotThrow(() -> {
+            try {
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                assertEquals(200, response.statusCode(), "Should receive OK response via injected URIBuilder");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MockWebServerTestException(REQUEST_INTERRUPTED_MESSAGE, e);
+            }
+        });
     }
 
     @Test
@@ -149,7 +178,8 @@ class MockWebServerManualStartTest {
                 assertEquals(200, response.statusCode(), "Should receive OK response");
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
             }
         });
     }

--- a/src/test/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtilTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtilTest.java
@@ -27,6 +27,7 @@ import okhttp3.tls.HandshakeCertificates;
 
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,6 +58,32 @@ class KeyMaterialUtilTest {
                     Arguments.of(7, KeyAlgorithm.RSA_2048),
                     Arguments.of(1, KeyAlgorithm.RSA_2048) // Single day certificate
             );
+        }
+
+        @Test
+        @DisplayName("Should honor an elliptic-curve key algorithm")
+        void shouldHonorEcKeyAlgorithm() {
+            var certificates = KeyMaterialUtil.createSelfSignedHandshakeCertificates(
+                    TEST_DURATION_DAYS, KeyAlgorithm.ECDSA_P_256);
+
+            var keyManager = (X509KeyManager) certificates.keyManager();
+            assertNotNull(keyManager.getServerAliases("EC", null),
+                    "Requesting ECDSA_P_256 must produce an EC key");
+            assertNull(keyManager.getServerAliases("RSA", null),
+                    "An EC certificate must not present an RSA key");
+        }
+
+        @Test
+        @DisplayName("Should default to an RSA key algorithm")
+        void shouldDefaultToRsaKeyAlgorithm() {
+            var certificates = KeyMaterialUtil.createSelfSignedHandshakeCertificates(
+                    TEST_DURATION_DAYS, KeyAlgorithm.RSA_2048);
+
+            var keyManager = (X509KeyManager) certificates.keyManager();
+            assertNotNull(keyManager.getServerAliases("RSA", null),
+                    "Requesting RSA_2048 must produce an RSA key");
+            assertNull(keyManager.getServerAliases("EC", null),
+                    "An RSA certificate must not present an EC key");
         }
     }
 


### PR DESCRIPTION
Implements cluster PR-4 of the `doc/review-26-07-04.md` fix plan: extension lifecycle and HTTPS/certificate handling.

## Extension lifecycle (`MockWebServerExtension`)
- **B1** — `beforeEach` no longer swallows setup failures. Every failure is rethrown so the real cause surfaces instead of a later, misleading `ParameterResolutionException: No MockWebServer instance available`.
- **B2** — `@EnableMockWebServer` is now resolved most-specific-first (test class → superclasses → the full enclosing-class chain). A `@Nested` class's own configuration wins over an outer one, and doubly-nested classes see the outermost annotation. *Behavioral change* — the pinning test was updated accordingly.
- **B3** — the injected `URIBuilder` binds lazily to the server and resolves its base URL at `build()` time, so injection works with `manualStart=true`.
- **B4** — `put`/`remove` use a single shared store-key constant.
- **B5** — removed the dead `ensureServerNotStarted` check.

## Certificate resolution (`CertificateResolver`)
- **B6** — the `SSLContext` is stored in the class-level store, so a later non-HTTPS class cannot receive a stale context and parallel classes with different certificates no longer race. The self-signed certificate cache stays at root.
- **B7** — `@TestProvidedCertificate` is resolved via `AnnotationSupport.findAnnotation(..., INCLUDE_ENCLOSING_CLASSES)`, adding superclass/enclosing/meta-annotation support.
- **B8** — an explicitly configured provider `methodName()` that does not resolve now fails fast instead of silently falling back to self-signed certificates.
- **B9** — unified on `getTestProvidedHandshakeCertificates` as the default provider-method name, keeping `provideHandshakeCertificates` as a documented legacy fallback; the lookup order is documented on the annotation.

## Key material (`KeyMaterialUtil`)
- **E1** — `createSelfSignedHandshakeCertificates` honors the requested `KeyAlgorithm` (EC → `ecdsa256()`, otherwise `rsa2048()`) instead of always producing RSA.
- **E2** — `convertToHandshakeCertificates` is deprecated (`forRemoval`) and its javadoc now states it generates fresh self-signed material rather than converting the input `SSLContext`.
- **E3** — `createSslContext` passes `null` for the `SecureRandom`, letting the provider supply securely seeded randomness instead of reseeding `SHA1PRNG` with a low-entropy timestamp.

## Regression tests (H14)
- Lazy `URIBuilder` injection under `manualStart`.
- Class-level `SSLContext` scoping.
- Fail-fast on an explicitly missing provider method.
- Provider-method-throws propagation wrapped as `IllegalStateException`.
- EC vs RSA key-algorithm selection.

Full suite: 217 tests green; `-Ppre-commit clean install` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6)_