### PR TITLE
docs: align documentation and javadoc with the code (G1-G14)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,8 @@ compared to the original.
     <dependency>
         <groupId>de.cuioss.test</groupId>
         <artifactId>cui-test-mockwebserver-junit5</artifactId>
+        <!-- Use the latest release; see the Maven Central badge above -->
+        <version>x.y.z</version>
     </dependency>
 ----
 
@@ -87,14 +89,15 @@ class MockWebServerTest {
         // ...
     }
 
-    // This method will be called by the @ModuleDispatcher annotation
+    // The bare @ModuleDispatcher on the test method defers to this method to obtain the dispatcher
     ModuleDispatcherElement getModuleDispatcher() {
-        return new BaseAllAcceptDispatcher("/api/posts")
-                .withPostResponse(new mockwebserver3.MockResponse.Builder()
-                        .code(201)
-                        .addHeader("Content-Type", "application/json")
-                        .body("{\"id\":\"123\",\"status\":\"created\"}")
-                        .build());
+        var dispatcher = new BaseAllAcceptDispatcher("/api/posts");
+        dispatcher.setMethodToResult(new mockwebserver3.MockResponse.Builder()
+                .code(201)
+                .addHeader("Content-Type", "application/json")
+                .body("{\"id\":\"123\",\"status\":\"created\"}")
+                .build(), HttpMethodMapper.POST);
+        return dispatcher;
     }
 }
 ----
@@ -210,33 +213,33 @@ class ManualStartTest {
         // Now the server is running
         assertTrue(server.getStarted());
 
-        // The URIBuilder is updated with the server's port
+        // The injected URIBuilder resolves the server URL lazily, so it now builds valid URIs
         URI uri = uriBuilder.addPathSegment("api").build();
         assertEquals(server.getPort(), uri.getPort());
 
-        // Don't forget to shut down the server
-        server.shutdown();
+        // Manual closing is normally unnecessary: the extension closes the server in its
+        // afterEach callback. Call close() explicitly only if you need to stop it earlier.
+        server.close();
     }
 }
 ----
 
 ==== Manual Server Start Considerations
 
-When using `manualStart = true`, you need to be careful with the injected `URIBuilder` parameter:
+When using `manualStart = true`, the injected `URIBuilder` binds its base URL lazily:
 
-* Before the server is started, the injected `URIBuilder` is a placeholder that cannot be used to build URIs
-* If you try to build a URI from this placeholder, it will throw an `IllegalStateException`
-* You must create a proper `URIBuilder` *after* manually starting the server
+* The base URL is resolved from the server the first time you call `build()`, not at injection time
+* You can therefore use the injected `URIBuilder` directly, as long as you start the server *before* building any URI
+* There is no need to create a separate `URIBuilder` after starting the server
 
 [source,java]
 ----
-// INCORRECT - Will throw IllegalStateException if server not started
+// CORRECT - start the server first, then build from the injected URIBuilder
+server.start();
 URI uri = uriBuilder.addPathSegment("api").build();
 
-// CORRECT - Create a proper URIBuilder after starting the server
-server.start();
-URIBuilder properUriBuilder = URIBuilder.from(server.url("/").url());
-URI uri = properUriBuilder.addPathSegment("api").build();
+// INCORRECT - building before the server is started cannot resolve the base URL yet
+URI uri = uriBuilder.addPathSegment("api").build(); // server not started
 ----
 
 === HTTPS Support and Certificates

--- a/README.adoc
+++ b/README.adoc
@@ -217,9 +217,7 @@ class ManualStartTest {
         URI uri = uriBuilder.addPathSegment("api").build();
         assertEquals(server.getPort(), uri.getPort());
 
-        // Manual closing is normally unnecessary: the extension closes the server in its
-        // afterEach callback. Call close() explicitly only if you need to stop it earlier.
-        server.close();
+        // Manual closing is unnecessary: the extension closes the server in its afterEach callback.
     }
 }
 ----

--- a/doc/HttpsSupport.adoc
+++ b/doc/HttpsSupport.adoc
@@ -103,6 +103,8 @@ class CustomCertificateTest {
 }
 ----
 
+The second argument to `KeyMaterialUtil.createSelfSignedHandshakeCertificates` is the `keyAlgorithm`, which selects the key algorithm of the generated certificate. Elliptic-curve values (whose name starts with `ECDSA`) produce an EC (ECDSA P-256) certificate; every other value, including the RSA variants and `null`, produces an RSA-2048 certificate.
+
 === Using a Provider Class
 
 You can also use a separate provider class for better reuse of certificate creation logic:

--- a/doc/Migration.adoc
+++ b/doc/Migration.adoc
@@ -87,7 +87,6 @@ For more complex scenarios, you can use the `@ModuleDispatcher` annotation and i
 
 [source,java]
 ----
-@ModuleDispatcher
 @EnableMockWebServer
 @ModuleDispatcher // No parameters means look for getModuleDispatcher() method
 class MyTest {
@@ -113,6 +112,7 @@ class MyTest {
                 return Set.of(HttpMethodMapper.GET);
             }
         };
+    }
 }
 ----
 
@@ -265,7 +265,7 @@ void testPostMethod(URIBuilder uriBuilder) {
 @MockResponseConfig(
     path = "/api/resource", 
     status = HttpServletResponse.SC_OK, 
-    headers = "Content-Type=application/json;ETag=W/123"
+    headers = {"Content-Type=application/json", "ETag=W/123"}
 )
 @Test
 void testResponseWithHeaders(URIBuilder uriBuilder) {

--- a/doc/MockResponse.adoc
+++ b/doc/MockResponse.adoc
@@ -1,4 +1,4 @@
-= Working with @MockResponse
+= Working with @MockResponseConfig
 :toc: macro
 :toclevels: 3
 :sectnumlevels: 1
@@ -57,18 +57,21 @@ The annotation supports different types of content:
 // Text content (Content-Type: text/plain)
 @MockResponseConfig(
     path = "/api/text",
+    status = 200,
     textContent = "Hello, World!"
 )
 
 // JSON content (Content-Type: application/json)
 @MockResponseConfig(
     path = "/api/json",
+    status = 200,
     jsonContentKeyValue = "message=Hello,count=42"
 )
 
 // Raw string content (no Content-Type set)
 @MockResponseConfig(
     path = "/api/raw",
+    status = 200,
     stringContent = "<custom>content</custom>"
 )
 ----
@@ -90,7 +93,7 @@ You can add custom headers to your responses:
 
 == Context-Aware Behavior
 
-Starting with version 1.2, `@MockResponseConfig` annotations are context-aware. This means that each test method only has access to:
+Starting with version 1.1, `@MockResponseConfig` annotations are context-aware. This means that each test method only has access to:
 
 1. Its own method-level `@MockResponseConfig` annotations
 2. Class-level `@MockResponseConfig` annotations from its containing class and parent classes

--- a/doc/ModuleDispatcher.adoc
+++ b/doc/ModuleDispatcher.adoc
@@ -86,7 +86,7 @@ class TestMethodDispatcherTest {
 
 === Using a Custom Dispatcher with Path-Based Responses
 
-You can create a custom dispatcher that uses the `RecordedRequest.getPath()` method to return different responses based on the request path:
+You can create a custom dispatcher that uses the `RecordedRequest.getUrl().encodedPath()` method to return different responses based on the request path:
 
 [source,java]
 ----
@@ -104,7 +104,7 @@ class PathBasedDispatcherTest {
 
             @Override
             public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
-                String path = request.getPath();
+                String path = request.getUrl().encodedPath();
 
                 // Return different responses based on the path
                 if (path.endsWith("/api/users/active")) {
@@ -306,7 +306,7 @@ public class CustomApiDispatcher implements ModuleDispatcherElement {
     @Override
     public Optional<MockResponse> handleGet(@NonNull RecordedRequest request) {
         // You can add custom logic here based on the request
-        if (request.getPath().endsWith("/special")) {
+        if (request.getUrl().encodedPath().endsWith("/special")) {
             return Optional.of(new MockResponse.Builder()
                 .code(200)
                 .body("{\"special\":true}")
@@ -347,6 +347,9 @@ public class JwksResolveDispatcher implements ModuleDispatcherElement {
 
     /** "/oidc/jwks.json" */
     public static final String LOCAL_PATH = "/oidc/jwks.json";
+
+    /** Classpath/file location of the JWKS document served by this dispatcher. */
+    private static final String PUBLIC_KEY_JWKS = "src/test/resources/token/test-public-key.jwks";
 
     @Getter
     @Setter
@@ -391,10 +394,15 @@ Implementation example:
 @EnableAutoWeld
 @EnablePortalConfiguration
 @EnableMockWebServer(useHttps = true)
-@ModuleDispatcher(UserApiDispatcher.class)
+@ModuleDispatcher // No parameters means look for getModuleDispatcher() method
 class TokenParserProducerTest implements ShouldBeNotNull<TokenParserProducer> {
 
     private final JwksResolveDispatcher jwksResolveDispatcher = new JwksResolveDispatcher();
+
+    // Registers the dispatcher so it actually handles requests and its callCounter advances
+    ModuleDispatcherElement getModuleDispatcher() {
+        return jwksResolveDispatcher;
+    }
 
     @BeforeEach
     void setupConfiguration(URIBuilder uriBuilder, SSLContext sslContext) {

--- a/src/main/java/de/cuioss/test/mockwebserver/EnableMockWebServer.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/EnableMockWebServer.java
@@ -37,7 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     &#64;Test
  *     void shouldTestWithServer(MockWebServer server) {
  *         // Use the server directly in your test
- *         server.enqueue(new MockResponse().setBody("Hello World"));
+ *         server.enqueue(new MockResponse.Builder().body("Hello World").build());
  *         // Make HTTP requests to server.url("/")
  *     }
  * }
@@ -51,8 +51,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     &#64;Test
  *     void shouldTestWithCustomPort(MockWebServer server) {
  *         server.start(8080);
- *         // Test with specific port
- *         server.shutdown();
+ *         // Test with specific port; the extension closes the server automatically in afterEach
  *     }
  * }
  * </pre>
@@ -124,7 +123,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *   <li>Manual server control with {@link #manualStart()}</li>
  *   <li>Support for custom {@link mockwebserver3.Dispatcher} implementations</li>
  *   <li>HTTPS support with both self-signed and custom certificates</li>
- *   <li>Parameter resolving for {@link MockWebServer}, port, URL, {@link URIBuilder}, and {@link javax.net.ssl.SSLContext}</li>
+ *   <li>Parameter resolving for {@link MockWebServer}, {@link URIBuilder}, and {@link javax.net.ssl.SSLContext}</li>
  * </ul>
  *
  * @author Oliver Wolff

--- a/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
@@ -102,10 +102,10 @@ import javax.net.ssl.SSLContext;
  *         server.setDispatcher(new Dispatcher() {
  *             @Override
  *             public MockResponse dispatch(RecordedRequest request) {
- *                 if ("/api/data".equals(request.getPath())) {
- *                     return new MockResponse().setBody("Hello World");
+ *                 if ("/api/data".equals(request.getUrl().encodedPath())) {
+ *                     return new MockResponse.Builder().body("Hello World").build();
  *                 }
- *                 return new MockResponse().setResponseCode(404);
+ *                 return new MockResponse.Builder().code(404).build();
  *             }
  *         });
  *

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
@@ -48,7 +48,7 @@ import static de.cuioss.tools.collect.CollectionLiterals.mutableSortedSet;
  *
  * // Customize GET response
  * dispatcher.getGetResult().setResponse(
- *     new MockResponse().setBody("{'data': 'test'}")
+ *     new MockResponse.Builder().body("{'data': 'test'}").build()
  * );
  *
  * // Reset to default responses
@@ -58,8 +58,8 @@ import static de.cuioss.tools.collect.CollectionLiterals.mutableSortedSet;
  * <h2>Default Responses</h2>
  * <ul>
  *   <li>GET: 200 OK with empty body</li>
- *   <li>POST: 201 Created</li>
- *   <li>PUT: 204 No Content</li>
+ *   <li>POST: 200 OK</li>
+ *   <li>PUT: 201 Created</li>
  *   <li>DELETE: 204 No Content</li>
  *   <li>HEAD: 200 OK</li>
  * </ul>

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
@@ -48,7 +48,7 @@ import java.util.Optional;
  * var dispatcher = new CombinedDispatcher()
  *     .addDispatcher(new UserApiDispatcher())
  *     .addDispatcher(new ProductApiDispatcher())
- *     .setEndWithTeapot(false); // Use 404 for unhandled requests
+ *     .endWithTeapot(false); // Use 404 for unhandled requests
  *
  * &#64;EnableMockWebServer
  * class ApiTest {

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
@@ -49,17 +49,15 @@ import java.util.Optional;
  * // Reset to default
  * handler.resetToDefaultResponse();
  *
- * // Create handler with specific default response
- * var customHandler = EndpointAnswerHandler.builder()
- *     .defaultResponse(RESPONSE_NO_CONTENT)
- *     .build();
+ * // Create handler with a specific default response for a given method
+ * var customHandler = new EndpointAnswerHandler(RESPONSE_NO_CONTENT, HttpMethodMapper.DELETE);
  * </pre>
  *
  * <h2>Factory Methods</h2>
  * <ul>
  *   <li>{@link #forPositiveGetRequest()} - Handler for GET requests (200 OK)</li>
- *   <li>{@link #forPositivePostRequest()} - Handler for POST requests (201 Created)</li>
- *   <li>{@link #forPositivePutRequest()} - Handler for PUT requests (204 No Content)</li>
+ *   <li>{@link #forPositivePostRequest()} - Handler for POST requests (200 OK)</li>
+ *   <li>{@link #forPositivePutRequest()} - Handler for PUT requests (201 Created)</li>
  *   <li>{@link #forPositiveDeleteRequest()} - Handler for DELETE requests (204 No Content)</li>
  * </ul>
  *
@@ -138,10 +136,11 @@ public class EndpointAnswerHandler {
     private MockResponse response;
 
     /**
-     * Default Constructor
+     * Creates a handler bound to a single HTTP method with a given default response.
      *
-     * @param defaultResponse
-     * @param httpMethod
+     * @param defaultResponse the response returned after {@link #resetToDefaultResponse()} and the
+     *                         initial value produced by {@link #respond()}
+     * @param httpMethod       the HTTP method this handler answers for
      */
     public EndpointAnswerHandler(MockResponse defaultResponse, HttpMethodMapper httpMethod) {
         this.httpMethod = httpMethod;
@@ -289,8 +288,15 @@ public class EndpointAnswerHandler {
     }
 
     /**
-     * @return An {@link EndpointAnswerHandler} resulting {@link #respond()} to
-     * return {@link Optional#empty()}
+     * Creates a handler that does not answer at all: {@link #respond()} returns {@link Optional#empty()},
+     * so the request falls through to the next dispatcher.
+     * <p>
+     * <strong>Note:</strong> despite the name, this does <em>not</em> produce an HTTP 204 "No Content"
+     * response — for that use {@link #RESPONSE_NO_CONTENT}. The name refers to "no response content
+     * emitted by this handler". (The method will be renamed to {@code passthrough} in the next major release.)
+     *
+     * @param httpMethod the HTTP method this handler is bound to
+     * @return an {@link EndpointAnswerHandler} whose {@link #respond()} returns {@link Optional#empty()}
      */
     public static EndpointAnswerHandler noContent(HttpMethodMapper httpMethod) {
         return new EndpointAnswerHandler(null, httpMethod);

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
@@ -50,7 +50,8 @@ import java.util.Optional;
  * handler.resetToDefaultResponse();
  *
  * // Create handler with a specific default response for a given method
- * var customHandler = new EndpointAnswerHandler(RESPONSE_NO_CONTENT, HttpMethodMapper.DELETE);
+ * var customHandler = new EndpointAnswerHandler(RESPONSE_NO_CONTENT, HttpMethodMapper.DELETE)
+ *         .resetToDefaultResponse();
  * </pre>
  *
  * <h2>Factory Methods</h2>
@@ -138,8 +139,8 @@ public class EndpointAnswerHandler {
     /**
      * Creates a handler bound to a single HTTP method with a given default response.
      *
-     * @param defaultResponse the response returned after {@link #resetToDefaultResponse()} and the
-     *                         initial value produced by {@link #respond()}
+     * @param defaultResponse the response applied by {@link #resetToDefaultResponse()} (the initial
+     *                         {@link #respond()} value is empty until that method is called)
      * @param httpMethod       the HTTP method this handler answers for
      */
     public EndpointAnswerHandler(MockResponse defaultResponse, HttpMethodMapper httpMethod) {

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * <ul>
  *   <li>Type-safe HTTP method mapping</li>
  *   <li>Automatic method routing</li>
- *   <li>Support for GET, POST, PUT, DELETE methods</li>
+ *   <li>Support for GET, POST, PUT, DELETE, HEAD methods</li>
  *   <li>Null-safe request handling</li>
  * </ul>
  *

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
@@ -45,10 +45,11 @@ import java.util.Set;
  *
  *     &#64;Override
  *     public Optional&lt;MockResponse&gt; handleGet(RecordedRequest request) {
- *         if (request.getPath().equals("/api/users/123")) {
- *             return Optional.of(new MockResponse()
- *                 .setResponseCode(200)
- *                 .setBody("{'id': '123', 'name': 'John'}"));
+ *         if (request.getUrl().encodedPath().equals("/api/users/123")) {
+ *             return Optional.of(new MockResponse.Builder()
+ *                 .code(200)
+ *                 .body("{'id': '123', 'name': 'John'}")
+ *                 .build());
  *         }
  *         return Optional.empty(); // Let other handlers try
  *     }
@@ -74,7 +75,7 @@ import java.util.Set;
  *   <li>Each dispatcher handles a specific URL path prefix</li>
  *   <li>Return {@link Optional#empty()} to allow other dispatchers to handle the request</li>
  *   <li>Can be combined using {@link CombinedDispatcher}</li>
- *   <li>Supports all standard HTTP methods (GET, POST, PUT, DELETE)</li>
+ *   <li>Supports all standard HTTP methods (GET, POST, PUT, DELETE, HEAD)</li>
  * </ul>
  *
  * @author Oliver Wolff

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Declarative mock-response configuration via the
+ * {@link de.cuioss.test.mockwebserver.mockresponse.MockResponseConfig} annotation.
+ *
+ * <h2>Contents</h2>
+ * <ul>
+ *   <li>{@link de.cuioss.test.mockwebserver.mockresponse.MockResponseConfig} - annotation declaring a
+ *       response for a specific path and HTTP method; repeatable via
+ *       {@link de.cuioss.test.mockwebserver.mockresponse.MockResponseConfigs}.</li>
+ *   <li>{@link de.cuioss.test.mockwebserver.mockresponse.MockResponseConfigResolver} - collects the
+ *       (class- and method-level) annotations for the current test.</li>
+ *   <li>{@link de.cuioss.test.mockwebserver.mockresponse.MockResponseConfigDispatcherElement} - serves
+ *       the configured responses as a {@code ModuleDispatcherElement}.</li>
+ * </ul>
+ *
+ * @author Oliver Wolff
+ * @see de.cuioss.test.mockwebserver
+ * @since 1.1
+ */
+package de.cuioss.test.mockwebserver.mockresponse;

--- a/src/main/java/de/cuioss/test/mockwebserver/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/package-info.java
@@ -28,6 +28,7 @@
  *   <li>Request Handling
  *     <ul>
  *       <li>{@link de.cuioss.test.mockwebserver.dispatcher} - Custom request dispatchers</li>
+ *       <li>{@link de.cuioss.test.mockwebserver.mockresponse} - Declarative {@code @MockResponseConfig} responses</li>
  *     </ul>
  *   </li>
  *   <li>HTTPS Support
@@ -78,11 +79,13 @@
  *   <li>{@link de.cuioss.test.mockwebserver.EnableMockWebServer} for server setup</li>
  *   <li>{@link de.cuioss.test.mockwebserver.MockWebServerExtension} for parameter injection</li>
  *   <li>{@link de.cuioss.test.mockwebserver.dispatcher} for request handling</li>
+ *   <li>{@link de.cuioss.test.mockwebserver.mockresponse} for declarative response configuration</li>
  *   <li>{@link de.cuioss.test.mockwebserver.ssl} for HTTPS configuration</li>
  * </ul>
  *
  * @author Oliver Wolff
  * @see de.cuioss.test.mockwebserver.dispatcher
+ * @see de.cuioss.test.mockwebserver.mockresponse
  * @see de.cuioss.test.mockwebserver.ssl
  * @see mockwebserver3.MockWebServer
  * @since 1.0

--- a/src/main/java/de/cuioss/test/mockwebserver/ssl/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/ssl/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * SSL/TLS key material support for HTTPS testing with
+ * {@link de.cuioss.test.mockwebserver.MockWebServerExtension}.
+ *
+ * <h2>Contents</h2>
+ * <ul>
+ *   <li>{@link de.cuioss.test.mockwebserver.ssl.KeyMaterialUtil} - generates self-signed
+ *       {@code HandshakeCertificates} (honoring the requested key algorithm) and converts them to an
+ *       {@link javax.net.ssl.SSLContext} for client configuration.</li>
+ * </ul>
+ *
+ * @author Oliver Wolff
+ * @see de.cuioss.test.mockwebserver
+ * @since 1.1
+ */
+package de.cuioss.test.mockwebserver.ssl;


### PR DESCRIPTION
Implements cluster PR-7 of the `doc/review-26-07-04.md` fix plan: bring the README, the `doc/*.adoc` guides, and the javadoc in line with the actual code (findings G1–G14). No behavioral changes — documentation and javadoc only, plus two new `package-info.java` files.

## README.adoc
- **G1** — replace the nonexistent `withPostResponse(...)` with the real `setMethodToResult(response, HttpMethodMapper.POST)` API and mockwebserver3 `MockResponse.Builder`.
- **G2** — `server.shutdown()` → `server.close()`, noting the extension closes the server automatically in `afterEach`.
- **G3** — the manual-start example now uses the injected `URIBuilder` directly (valid because the base URL binds lazily at `build()` time) instead of labeling the pattern "INCORRECT".
- **G4** — add a `<version>` to the Maven dependency snippet; correct the method-level `@ModuleDispatcher` comment to match the real resolution behavior (method-level is honored and defers to `getModuleDispatcher()`).

## doc/*.adoc
- **G5** (MockResponse.adoc) — title `@MockResponse` → `@MockResponseConfig`, add the required `status` attribute to the examples, unify the version on 1.1.
- **G6** (ModuleDispatcher.adoc) — `request.getPath()` → `request.getUrl().encodedPath()`, define the `PUBLIC_KEY_JWKS` constant, and register the dispatcher via `getModuleDispatcher()` so the asserted call counter advances.
- **G7** (Migration.adoc) — remove the duplicate `@ModuleDispatcher` (not `@Repeatable`), balance the braces, and use the array `headers = {"Content-Type=...", "ETag=..."}` syntax.
- **G8** (HttpsSupport.adoc) — document that `keyAlgorithm` selects the certificate key algorithm (EC vs RSA), now that it is honored.

## Javadoc
- **G9** — replace the removed `okhttp3.mockwebserver` API (`new MockResponse().setBody/.setResponseCode`, `request.getPath()`) with `MockResponse.Builder` and `request.getUrl().encodedPath()` in `MockWebServerExtension`, `EnableMockWebServer`, `ModuleDispatcherElement`, and `BaseAllAcceptDispatcher`.
- **G10** — correct the injectable-parameter list to `MockWebServer`, `URIBuilder`, `SSLContext`.
- **G11** — document the real default responses (POST 200 OK, PUT 201 Created) in `BaseAllAcceptDispatcher` and `EndpointAnswerHandler`.
- **G12** — fix the nonexistent `EndpointAnswerHandler.builder()` example, fill in the empty constructor `@param` tags, and clarify that `noContent(...)` produces a fall-through (empty) response, not HTTP 204.
- **G13** — `setEndWithTeapot` → `endWithTeapot`; add HEAD to the supported-method lists.
- **G14** — add `package-info.java` for the `ssl` and `mockresponse` packages (fixing unresolvable `{@link}`s) and reference `mockresponse` from the top-level package overview.

Full suite: 221 tests green; javadoc generation and `-Ppre-commit clean install` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM9YDMBrdKT15a62dtzau6)_