### PR TITLE
feat: add PATCH and OPTIONS to HttpMethodMapper

### DIFF
--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
@@ -21,7 +21,9 @@ import lombok.RequiredArgsConstructor;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 
-import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -108,17 +110,39 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
     private final EndpointAnswerHandler optionsResult = EndpointAnswerHandler.forPositiveOptionsRequest();
 
     /**
+     * Registry binding every {@link HttpMethodMapper} constant to its handler. Declared after the
+     * per-method fields so they are initialised first. {@link #buildHandlerRegistry()} fails fast when
+     * a constant has no handler, so adding an {@link HttpMethodMapper} value without wiring it here is
+     * a construction-time error rather than a silent gap.
+     */
+    private final Map<HttpMethodMapper, EndpointAnswerHandler> handlerRegistry = buildHandlerRegistry();
+
+    private Map<HttpMethodMapper, EndpointAnswerHandler> buildHandlerRegistry() {
+        Map<HttpMethodMapper, EndpointAnswerHandler> registry = new EnumMap<>(HttpMethodMapper.class);
+        registry.put(HttpMethodMapper.GET, getResult);
+        registry.put(HttpMethodMapper.POST, postResult);
+        registry.put(HttpMethodMapper.PUT, putResult);
+        registry.put(HttpMethodMapper.DELETE, deleteResult);
+        registry.put(HttpMethodMapper.HEAD, headResult);
+        registry.put(HttpMethodMapper.PATCH, patchResult);
+        registry.put(HttpMethodMapper.OPTIONS, optionsResult);
+
+        Set<HttpMethodMapper> missing = EnumSet.allOf(HttpMethodMapper.class);
+        missing.removeAll(registry.keySet());
+        if (!missing.isEmpty()) {
+            throw new IllegalStateException(
+                    "No EndpointAnswerHandler registered for HTTP method(s): " + missing
+                            + ". Every HttpMethodMapper constant must be wired in buildHandlerRegistry().");
+        }
+        return registry;
+    }
+
+    /**
      * Resets all contained {@link EndpointAnswerHandler}s to their default responses.
      * This is useful when you need to clear any custom responses between tests.
      */
     public void reset() {
-        getResult.resetToDefaultResponse();
-        postResult.resetToDefaultResponse();
-        putResult.resetToDefaultResponse();
-        deleteResult.resetToDefaultResponse();
-        headResult.resetToDefaultResponse();
-        patchResult.resetToDefaultResponse();
-        optionsResult.resetToDefaultResponse();
+        handlerRegistry.values().forEach(EndpointAnswerHandler::resetToDefaultResponse);
     }
 
     @Override
@@ -170,31 +194,7 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
      */
     public void setMethodToResult(MockResponse mockResponse, HttpMethodMapper... mapper) {
         for (HttpMethodMapper element : mapper) {
-            switch (element) {
-                case GET:
-                    getResult.setResponse(mockResponse);
-                    break;
-                case POST:
-                    postResult.setResponse(mockResponse);
-                    break;
-                case PUT:
-                    putResult.setResponse(mockResponse);
-                    break;
-                case DELETE:
-                    deleteResult.setResponse(mockResponse);
-                    break;
-                case HEAD:
-                    headResult.setResponse(mockResponse);
-                    break;
-                case PATCH:
-                    patchResult.setResponse(mockResponse);
-                    break;
-                case OPTIONS:
-                    optionsResult.setResponse(mockResponse);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported HTTP method: " + element + ". Supported methods are: " + Arrays.toString(HttpMethodMapper.values()));
-            }
+            handlerRegistry.get(element).setResponse(mockResponse);
         }
     }
 

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
@@ -35,7 +35,7 @@ import static de.cuioss.tools.collect.CollectionLiterals.mutableSortedSet;
  *
  * <h2>Features</h2>
  * <ul>
- *   <li>Pre-configured positive responses for GET, POST, PUT, DELETE</li>
+ *   <li>Pre-configured positive responses for GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS</li>
  *   <li>Per-method response customization</li>
  *   <li>Base URL path matching</li>
  *   <li>Response reset capability</li>
@@ -62,6 +62,8 @@ import static de.cuioss.tools.collect.CollectionLiterals.mutableSortedSet;
  *   <li>PUT: 201 Created</li>
  *   <li>DELETE: 204 No Content</li>
  *   <li>HEAD: 200 OK</li>
+ *   <li>PATCH: 200 OK</li>
+ *   <li>OPTIONS: 200 OK</li>
  * </ul>
  *
  * @author Oliver Wolff
@@ -94,6 +96,18 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
     private final EndpointAnswerHandler headResult = EndpointAnswerHandler.forPositiveGetRequest();
 
     /**
+     * Handles PATCH requests, defaulting to a 200 OK response.
+     */
+    @Getter
+    private final EndpointAnswerHandler patchResult = EndpointAnswerHandler.forPositivePatchRequest();
+
+    /**
+     * Handles OPTIONS requests, defaulting to a 200 OK response.
+     */
+    @Getter
+    private final EndpointAnswerHandler optionsResult = EndpointAnswerHandler.forPositiveOptionsRequest();
+
+    /**
      * Resets all contained {@link EndpointAnswerHandler}s to their default responses.
      * This is useful when you need to clear any custom responses between tests.
      */
@@ -103,6 +117,8 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
         putResult.resetToDefaultResponse();
         deleteResult.resetToDefaultResponse();
         headResult.resetToDefaultResponse();
+        patchResult.resetToDefaultResponse();
+        optionsResult.resetToDefaultResponse();
     }
 
     @Override
@@ -135,6 +151,16 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
         return headResult.respond();
     }
 
+    @Override
+    public Optional<MockResponse> handlePatch(@NonNull RecordedRequest request) {
+        return patchResult.respond();
+    }
+
+    @Override
+    public Optional<MockResponse> handleOptions(@NonNull RecordedRequest request) {
+        return optionsResult.respond();
+    }
+
     /**
      * Sets the result for a certain method
      *
@@ -159,6 +185,12 @@ public class BaseAllAcceptDispatcher implements ModuleDispatcherElement {
                     break;
                 case HEAD:
                     headResult.setResponse(mockResponse);
+                    break;
+                case PATCH:
+                    patchResult.setResponse(mockResponse);
+                    break;
+                case OPTIONS:
+                    optionsResult.setResponse(mockResponse);
                     break;
                 default:
                     throw new IllegalArgumentException("Unsupported HTTP method: " + element + ". Supported methods are: " + Arrays.toString(HttpMethodMapper.values()));

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
@@ -118,7 +118,7 @@ public class CombinedDispatcher extends Dispatcher {
         Optional<HttpMethodMapper> mapper = HttpMethodMapper.of(request);
         LOGGER.debug("Processing method '%s' with path '%s'", mapper.map(HttpMethodMapper::name).orElse("UNKNOWN"), path);
 
-        // Unknown/unsupported methods (e.g. OPTIONS, PATCH) fall through to the default response
+        // Unknown/unsupported methods (e.g. TRACE, CONNECT) fall through to the default response
         if (mapper.isPresent()) {
             for (ModuleDispatcherElement dispatcher : singleDispatcher) {
                 if (matchesBaseUrl(path, dispatcher.getBaseUrl())) {

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
@@ -289,6 +289,22 @@ public class EndpointAnswerHandler {
     }
 
     /**
+     * @return An {@link EndpointAnswerHandler} initialized with
+     * {@link #RESPONSE_OK}
+     */
+    public static EndpointAnswerHandler forPositivePatchRequest() {
+        return new EndpointAnswerHandler(RESPONSE_OK, HttpMethodMapper.PATCH).resetToDefaultResponse();
+    }
+
+    /**
+     * @return An {@link EndpointAnswerHandler} initialized with
+     * {@link #RESPONSE_OK}
+     */
+    public static EndpointAnswerHandler forPositiveOptionsRequest() {
+        return new EndpointAnswerHandler(RESPONSE_OK, HttpMethodMapper.OPTIONS).resetToDefaultResponse();
+    }
+
+    /**
      * Creates a handler that does not answer at all: {@link #respond()} returns {@link Optional#empty()},
      * so the request falls through to the next dispatcher.
      * <p>

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * <ul>
  *   <li>Type-safe HTTP method mapping</li>
  *   <li>Automatic method routing</li>
- *   <li>Support for GET, POST, PUT, DELETE, HEAD methods</li>
+ *   <li>Support for GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS methods</li>
  *   <li>Null-safe request handling</li>
  * </ul>
  *
@@ -96,6 +96,24 @@ public enum HttpMethodMapper {
         public Optional<MockResponse> handleMethod(ModuleDispatcherElement dispatcherElement, RecordedRequest request) {
             return dispatcherElement.handleHead(request);
         }
+    },
+    /**
+     * Handles HTTP PATCH requests by delegating to {@link ModuleDispatcherElement#handlePatch}.
+     */
+    PATCH {
+        @Override
+        public Optional<MockResponse> handleMethod(ModuleDispatcherElement dispatcherElement, RecordedRequest request) {
+            return dispatcherElement.handlePatch(request);
+        }
+    },
+    /**
+     * Handles HTTP OPTIONS requests by delegating to {@link ModuleDispatcherElement#handleOptions}.
+     */
+    OPTIONS {
+        @Override
+        public Optional<MockResponse> handleMethod(ModuleDispatcherElement dispatcherElement, RecordedRequest request) {
+            return dispatcherElement.handleOptions(request);
+        }
     };
 
     /**
@@ -113,7 +131,7 @@ public enum HttpMethodMapper {
     /**
      * Creates an HttpMethodMapper from a RecordedRequest's method.
      * <p>
-     * This lookup is total: an unsupported or unknown HTTP method (e.g. OPTIONS, PATCH, TRACE) yields
+     * This lookup is total: an unsupported or unknown HTTP method (e.g. TRACE, CONNECT) yields
      * an empty {@link Optional} rather than throwing, so callers can answer such requests with a
      * defined fallback instead of aborting the connection.
      *

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
@@ -75,7 +75,7 @@ import java.util.Set;
  *   <li>Each dispatcher handles a specific URL path prefix</li>
  *   <li>Return {@link Optional#empty()} to allow other dispatchers to handle the request</li>
  *   <li>Can be combined using {@link CombinedDispatcher}</li>
- *   <li>Supports all standard HTTP methods (GET, POST, PUT, DELETE, HEAD)</li>
+ *   <li>Supports all standard HTTP methods (GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS)</li>
  * </ul>
  *
  * @author Oliver Wolff
@@ -145,6 +145,28 @@ public interface ModuleDispatcherElement {
      *         or {@link Optional#empty()} to let other dispatchers handle it
      */
     default Optional<MockResponse> handleHead(@NonNull RecordedRequest request) {
+        return Optional.empty();
+    }
+
+    /**
+     * Handles HTTP PATCH requests.
+     *
+     * @param request the incoming request with path, headers, and body
+     * @return {@link Optional} containing the response if this dispatcher can handle the request,
+     *         or {@link Optional#empty()} to let other dispatchers handle it
+     */
+    default Optional<MockResponse> handlePatch(@NonNull RecordedRequest request) {
+        return Optional.empty();
+    }
+
+    /**
+     * Handles HTTP OPTIONS requests.
+     *
+     * @param request the incoming request with path, headers, and body
+     * @return {@link Optional} containing the response if this dispatcher can handle the request,
+     *         or {@link Optional#empty()} to let other dispatchers handle it
+     */
+    default Optional<MockResponse> handleOptions(@NonNull RecordedRequest request) {
         return Optional.empty();
     }
 

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/AllOkDispatcher.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/AllOkDispatcher.java
@@ -61,6 +61,16 @@ public class AllOkDispatcher implements ModuleDispatcherElement {
     }
 
     @Override
+    public Optional<MockResponse> handlePatch(@NonNull RecordedRequest request) {
+        return Optional.of(OK_RESPONSE);
+    }
+
+    @Override
+    public Optional<MockResponse> handleOptions(@NonNull RecordedRequest request) {
+        return Optional.of(OK_RESPONSE);
+    }
+
+    @Override
     public @NonNull Set<HttpMethodMapper> supportedMethods() {
         return Set.of(HttpMethodMapper.values());
     }

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import static de.cuioss.test.mockwebserver.dispatcher.EndpointAnswerHandlerTest.assertMockResponse;
 import static de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper.*;
 import static jakarta.servlet.http.HttpServletResponse.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class BaseAllAcceptDispatcherTest {
 
@@ -73,7 +74,7 @@ class BaseAllAcceptDispatcherTest {
     void shouldModifyMethodsToForbidden() {
         var dispatcher = new BaseAllAcceptDispatcher(DEFAULT_PATH);
 
-        dispatcher.setMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD, PATCH, OPTIONS);
+        dispatcher.setMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, HttpMethodMapper.values());
         assertMockResponse(dispatcher.handleDelete(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handleGet(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_FORBIDDEN);
@@ -112,7 +113,7 @@ class BaseAllAcceptDispatcherTest {
         var dispatcher = new BaseAllAcceptDispatcher(DEFAULT_PATH);
 
         // When every method is listed as "given", none fall into the "all but given" set: defaults stay
-        dispatcher.setAllButGivenMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD, PATCH, OPTIONS);
+        dispatcher.setAllButGivenMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, HttpMethodMapper.values());
         assertMockResponse(dispatcher.handleDelete(DUMMY).get(), SC_NO_CONTENT);
         assertMockResponse(dispatcher.handleGet(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
@@ -120,6 +121,18 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
+    }
+
+    @Test
+    void shouldRegisterAHandlerForEveryHttpMethod() {
+        var dispatcher = new BaseAllAcceptDispatcher(DEFAULT_PATH);
+
+        // Guards the registry against a future HttpMethodMapper constant landing without a handler:
+        // an unwired constant makes this throw rather than fail silently at dispatch time.
+        for (HttpMethodMapper method : HttpMethodMapper.values()) {
+            assertDoesNotThrow(() -> dispatcher.setMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, method),
+                    "No handler registered for " + method);
+        }
     }
 
     @Test

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
@@ -35,6 +35,8 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
     }
 
     @Test
@@ -48,6 +50,8 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
     }
 
     @Test
@@ -61,18 +65,22 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
     }
 
     @Test
     void shouldModifyMethodsToForbidden() {
         var dispatcher = new BaseAllAcceptDispatcher(DEFAULT_PATH);
 
-        dispatcher.setMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD);
+        dispatcher.setMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD, PATCH, OPTIONS);
         assertMockResponse(dispatcher.handleDelete(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handleGet(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_FORBIDDEN);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_FORBIDDEN);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_FORBIDDEN);
     }
 
     @Test
@@ -85,6 +93,8 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_NOT_IMPLEMENTED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_NOT_IMPLEMENTED);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_NOT_IMPLEMENTED);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_NOT_IMPLEMENTED);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_NOT_IMPLEMENTED);
 
         // Reset
         dispatcher.reset();
@@ -93,6 +103,8 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
     }
 
     @Test
@@ -100,12 +112,14 @@ class BaseAllAcceptDispatcherTest {
         var dispatcher = new BaseAllAcceptDispatcher(DEFAULT_PATH);
 
         // When every method is listed as "given", none fall into the "all but given" set: defaults stay
-        dispatcher.setAllButGivenMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD);
+        dispatcher.setAllButGivenMethodToResult(EndpointAnswerHandler.RESPONSE_FORBIDDEN, DELETE, GET, POST, PUT, HEAD, PATCH, OPTIONS);
         assertMockResponse(dispatcher.handleDelete(DUMMY).get(), SC_NO_CONTENT);
         assertMockResponse(dispatcher.handleGet(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_CREATED);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_OK);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_OK);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_OK);
     }
 
     @Test
@@ -119,6 +133,8 @@ class BaseAllAcceptDispatcherTest {
         assertMockResponse(dispatcher.handlePut(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handlePost(DUMMY).get(), SC_FORBIDDEN);
         assertMockResponse(dispatcher.handleHead(DUMMY).get(), SC_FORBIDDEN);
+        assertMockResponse(dispatcher.handlePatch(DUMMY).get(), SC_FORBIDDEN);
+        assertMockResponse(dispatcher.handleOptions(DUMMY).get(), SC_FORBIDDEN);
     }
 
 }

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
@@ -17,6 +17,8 @@ package de.cuioss.test.mockwebserver.dispatcher;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static de.cuioss.test.mockwebserver.dispatcher.CombinedDispatcher.HTTP_CODE_NOT_FOUND;
 import static de.cuioss.test.mockwebserver.dispatcher.CombinedDispatcher.HTTP_CODE_TEAPOT;
 import static de.cuioss.tools.collect.CollectionLiterals.mutableList;
@@ -71,17 +73,42 @@ class CombinedDispatcherTest {
 
     @Test
     void shouldReturnDefaultForUnsupportedMethod() {
-        // PATCH is not a supported HttpMethodMapper: it must fall through to the default response
+        // TRACE is not a mapped HttpMethodMapper: it must fall through to the default response
         // instead of throwing out of dispatch().
         var dispatcher = new CombinedDispatcher(okDispatcher);
-        var teapot = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("PATCH", AllOkDispatcher.BASE + "/x")));
+        var teapot = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("TRACE", AllOkDispatcher.BASE + "/x")));
         assertTrue(teapot.getStatus().contains(String.valueOf(HTTP_CODE_TEAPOT)),
                 "Unsupported method should yield the teapot default, was: " + teapot.getStatus());
 
         dispatcher.endWithTeapot(false);
-        var notFound = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("OPTIONS", AllOkDispatcher.BASE + "/x")));
+        var notFound = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("CONNECT", AllOkDispatcher.BASE + "/x")));
         assertTrue(notFound.getStatus().contains(String.valueOf(HTTP_CODE_NOT_FOUND)),
                 "Unsupported method should yield 404 when teapot is disabled, was: " + notFound.getStatus());
+    }
+
+    @Test
+    void shouldRoutePatchAndOptionsToTheirHandlers() {
+        // PATCH and OPTIONS are mapped constants, so dispatch() must reach handlePatch/handleOptions
+        // on the dispatcher element rather than falling through to the default response.
+        var dispatcher = new CombinedDispatcher(okDispatcher);
+
+        var patched = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("PATCH", AllOkDispatcher.BASE + "/x")));
+        assertTrue(patched.getStatus().contains(String.valueOf(SC_OK)),
+                "PATCH should reach handlePatch and yield 200, was: " + patched.getStatus());
+
+        var optioned = assertDoesNotThrow(() -> dispatcher.dispatch(DispatcherTestSupport.createRequest("OPTIONS", AllOkDispatcher.BASE + "/x")));
+        assertTrue(optioned.getStatus().contains(String.valueOf(SC_OK)),
+                "OPTIONS should reach handleOptions and yield 200, was: " + optioned.getStatus());
+    }
+
+    @Test
+    void shouldMapPatchAndOptionsMethodNames() {
+        assertEquals(Optional.of(HttpMethodMapper.PATCH),
+                HttpMethodMapper.of(DispatcherTestSupport.createRequest("PATCH", "/x")));
+        assertEquals(Optional.of(HttpMethodMapper.OPTIONS),
+                HttpMethodMapper.of(DispatcherTestSupport.createRequest("OPTIONS", "/x")));
+        assertEquals(Optional.empty(),
+                HttpMethodMapper.of(DispatcherTestSupport.createRequest("TRACE", "/x")));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`HttpMethodMapper` declares only `GET`, `POST`, `PUT`, `DELETE`, `HEAD`. Since `ModuleDispatcherElement.supportedMethods()` returns `Set<HttpMethodMapper>`, there is no way to register a PATCH or OPTIONS handler — a consumer testing a client that issues those methods cannot drive them through `CombinedDispatcher` at all.

Surfaced while building an HTTP-method-aware 304 test matrix in `cui-http`, which needs PATCH coverage.

## Change

| File | What |
|---|---|
| `HttpMethodMapper` | `PATCH` + `OPTIONS` constants, delegating to two new hooks |
| `ModuleDispatcherElement` | `handlePatch` / `handleOptions` defaults |
| `EndpointAnswerHandler` | `forPositivePatchRequest()` / `forPositiveOptionsRequest()` |
| `BaseAllAcceptDispatcher` | `patchResult` / `optionsResult`, both hooks, `reset()`, switch cases |

## Why BaseAllAcceptDispatcher is in scope

Adding enum constants is **not** additive for code that enumerates `values()`. `setAllButGivenMethodToResult` builds its set from `values()` and passes it to `setMethodToResult`, whose `default:` branch throws `IllegalArgumentException`. Adding the constants alone would have made that method throw for **every** caller — including the existing `shouldModifyOtherMethodsWithNull` test.

## Test-premise drift, fixed rather than ignored

Three existing tests kept passing but stopped meaning what they say:

- `shouldReturnDefaultForUnsupportedMethod` used PATCH/OPTIONS as its *unmapped-method* examples — precisely what this PR makes mapped. Switched to TRACE/CONNECT, so it still exercises the fall-through.
- `shouldKeepDefaultsWhenAllMethodsAreExcluded` enumerates methods explicitly; PATCH/OPTIONS would silently have fallen into the "all but given" set, making the name false while assertions still passed. Both now listed.
- `AllOkDispatcher` declares `Set.of(HttpMethodMapper.values())` but overrode five hooks; it now overrides all seven.

New coverage: PATCH/OPTIONS reach their handlers through `CombinedDispatcher`, `HttpMethodMapper.of` maps both, and the `BaseAllAcceptDispatcher` suite asserts the two new methods throughout.

## Compatibility

Source- and binary-compatible for implementors: both interface methods are `default`. Behaviour changes only for a `RecordedRequest` carrying PATCH or OPTIONS, which previously always fell through to the dispatcher default.

## Verification

`verify` green — 223 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgKe3yhkowm8VVs1m4xCVW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PATCH and OPTIONS requests across dispatching and response handling.
  * Added positive-response helpers for PATCH and OPTIONS, returning 200 OK by default.
  * Added configurable handling, filtering, and reset behavior for the new methods.

* **Documentation**
  * Clarified that TRACE and CONNECT remain unsupported and use the configured default response.

* **Tests**
  * Expanded coverage for PATCH and OPTIONS dispatching, filtering, defaults, and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->