### PR TITLE
ci: trigger the Maven build on merge_group

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,9 @@
 name: Maven Build
 
 on:
+  # Required so the 'build / conclusion' status check runs on the merge-queue
+  # branch; without it, queued PRs stay CLEAN but never merge (queue times out).
+  merge_group:
   push:
     branches: [main, "feature/*", "fix/*", "chore/*", "release/*", "dependabot/**"]
   pull_request:


### PR DESCRIPTION
A merge queue does not build the PR ref. It builds a candidate on `refs/heads/gh-readonly-queue/main/...` and dispatches the **`merge_group`** event.

Without this trigger, once a queue is enabled:

1. queue entry created → no workflow runs
2. required `build / conclusion` never reports
3. entry ejected at the 60-minute timeout

Net effect: **nothing can ever merge into `main`.** So the trigger has to land before the queue is enabled, not with it.

This PR is inert on its own — no queue exists on this repo yet, and `merge_group` events are only dispatched by one. The queue follows from `cuioss-organization`'s `merge_queue_repos`.

Verified on `cui-http`, which has had the trigger and a live queue since 2026-08-26 — five `merge_group` runs on `gh-readonly-queue/main/pr-*` branches, all `success`. The reusable workflow already handles the event; no change is needed there.

Validated locally:

```
triggers: ['merge_group', 'push', 'pull_request', 'workflow_dispatch']
```