### PR TITLE
chore: declare inceptionYear 2025 and normalise copyright headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>cui-test-mockwebserver-junit5</artifactId>
     <version>1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <!-- Must be declared: <inceptionYear> is inherited, and the license plugin binds
+         the copyright ${year} to it. Without this, this project would report
+         cui-parent-pom's 2022 and restamp every header on each -Ppre-commit run. -->
+    <inceptionYear>2025</inceptionYear>
     <name>mockwebserver junit5 plugin</name>
     <description>A junit 5 extension for MockWebServer providing some convenience, compared to the original.
     </description>
@@ -30,7 +34,7 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven.jar.plugin.automatic.module.name>de.cuioss.test.mockwebserver</maven.jar.plugin.automatic.module.name>
         <version.okhttp3>5.5.0</version.okhttp3>
         <version.jakarta.servlet-api>6.1.0</version.jakarta.servlet-api>
@@ -99,4 +103,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/de/cuioss/test/mockwebserver/CertificateResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/CertificateResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,7 +159,7 @@ class CertificateResolver {
             }
 
             return Optional.empty();
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Error resolving HandshakeCertificates from provider " + providerClass.getName(), e);
         }
@@ -175,7 +175,7 @@ class CertificateResolver {
     Object createProviderInstance(Class<?> providerClass) {
         try {
             return ReflectionUtils.newInstance(providerClass);
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Could not create instance of provider class " + providerClass.getName(), e);
         }
@@ -232,7 +232,7 @@ class CertificateResolver {
                     config.getKeyAlgorithm(), config.getCertificateDuration());
 
             return Optional.of(certificates);
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             LOGGER.error(e, "Failed to create self-signed certificates");
             return Optional.empty();
         }
@@ -291,7 +291,7 @@ class CertificateResolver {
             LOGGER.debug("Stored SSLContext for parameter resolution");
 
             return sslContext;
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             String errorMessage = "Failed to create or store SSLContext";
             LOGGER.error(e, errorMessage);
             throw new IllegalStateException(errorMessage, e);

--- a/src/main/java/de/cuioss/test/mockwebserver/EnableMockWebServer.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/EnableMockWebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/MockServerConfig.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/MockServerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/MockWebServerExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
             // We've successfully stored the server in context, so don't close it in the finally block
             server = null;
             LOGGER.debug("MockWebServer setup completed successfully");
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             // Never continue silently: a swallowed setup failure surfaces later as a misleading
             // "No MockWebServer instance available" and hides the real cause.
             LOGGER.error(e, "Error during MockWebServer setup: %s", e.getMessage());
@@ -212,7 +212,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
                 try {
                     server.close();
                     LOGGER.debug("Closed MockWebServer after a failed setup");
-                } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException closeEx) {
+                } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException closeEx) {
                     LOGGER.warn("Failed to close MockWebServer during exception handling: %s", closeEx.getMessage());
                 }
             }
@@ -291,7 +291,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
 
                 // Store certificates for parameter resolution
                 certificateResolver.createAndStoreSSLContext(context, handshakeCertificates.get());
-            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
                 String errorMessage = "Failed to configure HTTPS with available certificates";
                 LOGGER.error(e, errorMessage);
                 throw new IllegalStateException(errorMessage, e);
@@ -343,7 +343,7 @@ public class MockWebServerExtension implements AfterEachCallback, BeforeEachCall
                 } else {
                     LOGGER.debug("Server was not started, no shutdown needed");
                 }
-            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+            } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
                 LOGGER.error(e, "Failed to shutdown MockWebServer");
                 throw new IllegalStateException("Failed to properly shutdown MockWebServer", e);
             } finally {

--- a/src/main/java/de/cuioss/test/mockwebserver/TestProvidedCertificate.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/TestProvidedCertificate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/URIBuilder.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/URIBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolutionException.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolutionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,7 +210,9 @@ public class DispatcherResolver {
         try {
             Object target = Modifier.isStatic(method.getModifiers()) ? null : ReflectionUtils.newInstance(providerClass);
             return ReflectionUtils.invokeMethod(method, target);
-        } catch (RuntimeException e) {
+        }
+        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+        catch (RuntimeException e) {
             throw new DispatcherResolutionException(
                     "Provider method %s.%s could not be invoked: %s".formatted(providerClass.getName(), methodName, e.getMessage()), e);
         }
@@ -253,7 +255,9 @@ public class DispatcherResolver {
         Object result;
         try {
             result = ReflectionUtils.invokeMethod(method, testInstance);
-        } catch (RuntimeException e) {
+        }
+        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+        catch (RuntimeException e) {
             throw new DispatcherResolutionException("getModuleDispatcher method threw an exception", e);
         }
         if (result == null) {

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/HttpMethodMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,11 +56,11 @@ public enum HttpMethodMapper {
      * Handles HTTP GET requests by delegating to {@link ModuleDispatcherElement#handleGet}.
      */
     GET {
-        @Override
-        public Optional<MockResponse> handleMethod(ModuleDispatcherElement dispatcherElement, RecordedRequest request) {
-            return dispatcherElement.handleGet(request);
-        }
-    },
+    @Override
+    public Optional<MockResponse> handleMethod(ModuleDispatcherElement dispatcherElement, RecordedRequest request) {
+        return dispatcherElement.handleGet(request);
+    }
+},
     /**
      * Handles HTTP POST requests by delegating to {@link ModuleDispatcherElement#handlePost}.
      */

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcher.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/ModuleDispatcherElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/dispatcher/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/dispatcher/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfig.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElement.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,7 +174,12 @@ public class MockResponseConfigResolver {
             result.add(new MockResponseConfigDispatcherElement(annotation));
             LOGGER.debug("Added MockResponseConfig for path %s and method %s", annotation.path(), annotation.method());
         } catch (IllegalArgumentException e) {
-            LOGGER.error(e, "Failed to create MockResponseConfigDispatcherElement for path %s: %s",
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Failed to create MockResponseConfigDispatcherElement for path %s: %s",
                     annotation.path(), e.getMessage());
         }
     }

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigs.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/mockresponse/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/mockresponse/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtil.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class KeyMaterialUtil {
                     .heldCertificate(heldCertificate)
                     .addTrustedCertificate(heldCertificate.certificate())
                     .build();
-        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (RuntimeException e) {
+        } /*~~(TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (RuntimeException e) {
             throw new IllegalStateException("Failed to create self-signed HandshakeCertificates", e);
         }
     }

--- a/src/main/java/de/cuioss/test/mockwebserver/ssl/package-info.java
+++ b/src/main/java/de/cuioss/test/mockwebserver/ssl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTestUtil.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/CertificateResolverTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerConfigurationTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,8 @@ class MockWebServerConfigurationTest {
                 } catch (InterruptedException e) {
                     // Restore the interrupted status
                     Thread.currentThread().interrupt();
-                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                    throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
                 }
             });
         }
@@ -128,7 +129,8 @@ class MockWebServerConfigurationTest {
                 } catch (InterruptedException e) {
                     // Restore the interrupted status
                     Thread.currentThread().interrupt();
-                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                    throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
                 }
             });
         }
@@ -177,7 +179,8 @@ class MockWebServerConfigurationTest {
                 } catch (InterruptedException e) {
                     // Restore the interrupted status
                     Thread.currentThread().interrupt();
-                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                    throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
                 }
             });
         }
@@ -228,7 +231,8 @@ class MockWebServerConfigurationTest {
                 } catch (InterruptedException e) {
                     // Restore the interrupted status
                     Thread.currentThread().interrupt();
-                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
+                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/
+                    throw new RuntimeException(REQUEST_INTERRUPTED_MESSAGE, e);
                 }
             });
         }

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionCertificateTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionCertificateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionCornerCasesTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionCornerCasesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -59,7 +58,7 @@ class MockWebServerExtensionCornerCasesTest {
                 CUSTOM_HEADER_NAME + "=" + CUSTOM_HEADER_VALUE,
                 CONTENT_TYPE_HEADER + "=" + JSON_CONTENT_TYPE
         })
-        void shouldHandleCustomResponseHeaders(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldHandleCustomResponseHeaders(URIBuilder uriBuilder) throws Exception {
 
             // Create HTTP client with timeout
             HttpClient client = HttpClient.newBuilder()

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionErrorHandlingTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionErrorHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerExtensionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import mockwebserver3.MockWebServer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -59,7 +58,7 @@ class MockWebServerExtensionTest {
      */
     @Test
     @DisplayName("Should handle a simple GET request")
-    void shouldHandleSimpleRequest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void shouldHandleSimpleRequest(URIBuilder uriBuilder) throws Exception {
         // Arrange
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest request = HttpRequest.newBuilder()

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerInheritanceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerManualStartTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerManualStartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerParameterResolutionTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerParameterResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/MockWebServerTestException.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/MockWebServerTestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderBasicTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderEncodingTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderEncodingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderExceptionTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderPathSegmentTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderPathSegmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderPlaceholderTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderPlaceholderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderQueryParameterTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderQueryParameterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/URIBuilderTestBase.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/URIBuilderTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/UrlBuilderParameterResolvingTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/UrlBuilderParameterResolvingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -73,7 +72,7 @@ class UrlBuilderParameterResolvingTest {
 
 
     @Test
-    void shouldInjectUrlBuilder(URIBuilder urlBuilder) throws IOException, InterruptedException {
+    void shouldInjectUrlBuilder(URIBuilder urlBuilder) throws Exception {
         // Verify the URL builder is injected
         assertNotNull(urlBuilder, "URL builder should be injected");
 

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/AllOkDispatcher.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/AllOkDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/BaseAllAcceptDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/CombinedDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverAdvancedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverMethodTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherTestSupport.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/DispatcherTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandlerTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/EndpointAnswerHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/EndpointDispatcherExampleTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/EndpointDispatcherExampleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import mockwebserver3.MockResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -39,7 +38,7 @@ class EndpointDispatcherExampleTest {
 
     @Test
     @DisplayName("Should handle requests using EndpointAnswerHandler")
-    void withEndpointDispatcher(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void withEndpointDispatcher(URIBuilder uriBuilder) throws Exception {
 
         // Create HttpClient
         HttpClient client = HttpClient.newHttpClient();

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/PassThroughDispatcher.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/PassThroughDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/PathBasedDispatcherTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/PathBasedDispatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/dispatcher/TestDispatcherElement.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/dispatcher/TestDispatcherElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/https/HttpsTests.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/https/HttpsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import okhttp3.tls.HandshakeCertificates;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -86,7 +85,7 @@ class HttpsTests {
 
         @Test
         @DisplayName("Should successfully connect to HTTPS server with extension-provided certificate")
-        void shouldConnectToHttpsServer(URIBuilder serverURIBuilder, SSLContext sslContext) throws IOException, InterruptedException {
+        void shouldConnectToHttpsServer(URIBuilder serverURIBuilder, SSLContext sslContext) throws Exception {
             // Arrange
             assertNotNull(sslContext, SSL_CONTEXT_ASSERTION_MESSAGE);
             assertNotNull(serverURIBuilder, URL_BUILDER_ASSERTION_MESSAGE);
@@ -174,7 +173,7 @@ class HttpsTests {
 
         @Test
         @DisplayName("Should successfully connect to HTTPS server with test-provided certificate")
-        void shouldConnectToHttpsServer(URIBuilder serverURIBuilder, SSLContext sslContext, MockWebServer mockWebServer) throws IOException, InterruptedException {
+        void shouldConnectToHttpsServer(URIBuilder serverURIBuilder, SSLContext sslContext, MockWebServer mockWebServer) throws Exception {
             // Arrange
             assertNotNull(handshakeCertificates, "HandshakeCertificates should have been created by the test");
             assertNotNull(sslContext, SSL_CONTEXT_ASSERTION_MESSAGE);
@@ -222,7 +221,7 @@ class HttpsTests {
 
         @Test
         @DisplayName("Should successfully connect to HTTPS server with provider class certificate")
-        void shouldConnectToHttpsServer(MockWebServer server, URIBuilder serverURIBuilder, SSLContext sslContext) throws IOException, InterruptedException {
+        void shouldConnectToHttpsServer(MockWebServer server, URIBuilder serverURIBuilder, SSLContext sslContext) throws Exception {
             // Arrange
             assertNotNull(sslContext, SSL_CONTEXT_ASSERTION_MESSAGE);
             assertNotNull(serverURIBuilder, URL_BUILDER_ASSERTION_MESSAGE);
@@ -334,7 +333,7 @@ class HttpsTests {
 
         @Test
         @DisplayName("Should inject SSLContext parameter directly")
-        void shouldInjectSslContextParameter(URIBuilder serverURIBuilder, SSLContext sslContext) throws IOException, InterruptedException {
+        void shouldInjectSslContextParameter(URIBuilder serverURIBuilder, SSLContext sslContext) throws Exception {
             // Arrange
             assertNotNull(sslContext, SSL_CONTEXT_ASSERTION_MESSAGE);
             assertEquals(HTTPS_SCHEME, serverURIBuilder.getScheme(), HTTPS_SCHEME_ASSERTION_MESSAGE);

--- a/src/test/java/de/cuioss/test/mockwebserver/https/TestCertificateProvider.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/https/TestCertificateProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/https/package-info.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/https/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/ChildInheritanceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/ChildInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.cuioss.test.mockwebserver.URIBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -38,7 +37,7 @@ class ChildInheritanceTest extends InheritanceHierarchyTest {
     @Test
     @DisplayName("Child class should access its own annotations and parent class annotations")
     @MockResponseConfig(path = "/api/child-method", status = 200, textContent = "Child Method Response")
-    void childClassTest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void childClassTest(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/ContextAwareMockResponseConfigTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/ContextAwareMockResponseConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -45,7 +44,7 @@ class ContextAwareMockResponseConfigTest {
     @Test
     @DisplayName("Should only access method A and class-level responses")
     @MockResponseConfig(path = "/api/method-a", status = 200, textContent = "Method A Response")
-    void shouldOnlyAccessMethodAAndClassLevelResponses(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void shouldOnlyAccessMethodAAndClassLevelResponses(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();
@@ -83,7 +82,7 @@ class ContextAwareMockResponseConfigTest {
     @Test
     @DisplayName("Should only access method B and class-level responses")
     @MockResponseConfig(path = "/api/method-b", status = 200, textContent = "Method B Response")
-    void shouldOnlyAccessMethodBAndClassLevelResponses(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void shouldOnlyAccessMethodBAndClassLevelResponses(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();
@@ -125,7 +124,7 @@ class ContextAwareMockResponseConfigTest {
         @Test
         @DisplayName("Should only access nested method and parent responses")
         @MockResponseConfig(path = "/api/nested-method", status = 200, textContent = "Nested Method Response")
-        void shouldOnlyAccessNestedMethodAndParentResponses(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldOnlyAccessNestedMethodAndParentResponses(URIBuilder uriBuilder) throws Exception {
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
                     .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/DeeplyNestedClassesTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/DeeplyNestedClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -44,7 +43,7 @@ class DeeplyNestedClassesTest {
     @Test
     @DisplayName("Outer class should only access its own annotations")
     @MockResponseConfig(path = "/api/outer-method", status = 200, textContent = "Outer Method Response")
-    void outerClassTest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void outerClassTest(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();
@@ -87,7 +86,7 @@ class DeeplyNestedClassesTest {
         @Test
         @DisplayName("Level 1 nested class should access its own annotations and outer class annotations")
         @MockResponseConfig(path = "/api/level1-method", status = 200, textContent = "Level 1 Method Response")
-        void level1Test(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void level1Test(URIBuilder uriBuilder) throws Exception {
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
                     .build();
@@ -149,7 +148,7 @@ class DeeplyNestedClassesTest {
             @Test
             @DisplayName("Level 2 nested class should access its own annotations and all ancestor class annotations")
             @MockResponseConfig(path = "/api/level2-method", status = 200, textContent = "Level 2 Method Response")
-            void level2Test(URIBuilder uriBuilder) throws IOException, InterruptedException {
+            void level2Test(URIBuilder uriBuilder) throws Exception {
                 HttpClient client = HttpClient.newBuilder()
                         .connectTimeout(TIMEOUT)
                         .build();
@@ -229,7 +228,7 @@ class DeeplyNestedClassesTest {
                 @Test
                 @DisplayName("Level 3 nested class should access its own annotations and all ancestor class annotations")
                 @MockResponseConfig(path = "/api/level3-method", status = 200, textContent = "Level 3 Method Response")
-                void level3Test(URIBuilder uriBuilder) throws IOException, InterruptedException {
+                void level3Test(URIBuilder uriBuilder) throws Exception {
                     HttpClient client = HttpClient.newBuilder()
                             .connectTimeout(TIMEOUT)
                             .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/GrandchildInheritanceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/GrandchildInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.cuioss.test.mockwebserver.URIBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -38,7 +37,7 @@ class GrandchildInheritanceTest extends ChildInheritanceTest {
     @Test
     @DisplayName("Grandchild class should access its own annotations and all ancestor class annotations")
     @MockResponseConfig(path = "/api/grandchild-method", status = 200, textContent = "Grandchild Method Response")
-    void grandchildClassTest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void grandchildClassTest(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/InheritanceHierarchyTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/InheritanceHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.cuioss.test.mockwebserver.URIBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -43,7 +42,7 @@ class InheritanceHierarchyTest {
     @Test
     @DisplayName("Base class should only access its own annotations")
     @MockResponseConfig(path = "/api/base-method", status = 200, textContent = "Base Method Response")
-    void baseClassTest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void baseClassTest(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElementTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigDispatcherElementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,16 @@ package de.cuioss.test.mockwebserver.mockresponse;
 import de.cuioss.test.mockwebserver.dispatcher.HttpMethodMapper;
 import mockwebserver3.MockResponse;
 import mockwebserver3.RecordedRequest;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okio.Buffer;
+import okio.ByteString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import okhttp3.Headers;
-import okhttp3.HttpUrl;
-import okio.Buffer;
-import okio.ByteString;
 
 import java.util.Collections;
 import java.util.Set;
@@ -321,7 +320,7 @@ class MockResponseConfigDispatcherElementTest {
                 return buffer.readUtf8();
             }
             return "";
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/ catch (Exception e) {
             return "Error reading body: " + e.getMessage();
         }
     }

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigPrecedenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,19 +54,19 @@ class MockResponseConfigPrecedenceTest {
 
     @Test
     @DisplayName("Method-level annotation overrides class-level for the same path and method")
-    void methodOverridesClass() throws NoSuchMethodException {
+    void methodOverridesClass() throws Exception {
         Method method = OverrideFixture.class.getDeclaredMethod("overriding");
         List<ModuleDispatcherElement> elements =
                 MockResponseConfigResolver.resolveFromAnnotations(OverrideFixture.class, method);
 
         assertEquals(1, elements.size(), "Duplicate path+method must be de-duplicated to a single element");
-        assertEquals("method-level", body(elements.get(0), "/data"),
+        assertEquals("method-level", body(elements.getFirst(), "/data"),
                 "The method-level annotation must win over the class-level one");
     }
 
     @Test
     @DisplayName("Distinct path+method combinations are all retained")
-    void distinctCombinationsRetained() throws NoSuchMethodException {
+    void distinctCombinationsRetained() throws Exception {
         Method method = DistinctFixture.class.getDeclaredMethod("distinct");
         List<ModuleDispatcherElement> elements =
                 MockResponseConfigResolver.resolveFromAnnotations(DistinctFixture.class, method);
@@ -81,7 +81,7 @@ class MockResponseConfigPrecedenceTest {
                 MockResponseConfigResolver.resolveFromAnnotations(DistinctFixture.class);
 
         assertEquals(1, elements.size(), "Legacy mode collects only the class-level annotation");
-        assertEquals("class", body(elements.get(0), "/class-only"),
+        assertEquals("class", body(elements.getFirst(), "/class-only"),
                 "Legacy mode must resolve the class-level annotation");
     }
 

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolverTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseConfigResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ class MockResponseConfigResolverTest {
 
         @Test
         @DisplayName("Should resolve MockResponseConfig annotation on the context method")
-        void shouldResolveMethodAnnotation() throws NoSuchMethodException {
+        void shouldResolveMethodAnnotation() throws Exception {
             // Arrange - method-level annotations are resolved for the current test method (context aware)
             Method testMethod = ClassWithMethodAnnotation.class.getDeclaredMethod("testMethod");
 
@@ -108,7 +108,7 @@ class MockResponseConfigResolverTest {
 
         @Test
         @DisplayName("Should resolve annotations from the nested class and its enclosing class for a nested test method")
-        void shouldResolveNestedClassAnnotations() throws NoSuchMethodException {
+        void shouldResolveNestedClassAnnotations() throws Exception {
             // Arrange - resolve for a method declared in the nested class (context aware)
             Method testMethod = ClassWithNestedClassTest.NestedTestClass.class.getDeclaredMethod("nestedTest");
 
@@ -130,7 +130,7 @@ class MockResponseConfigResolverTest {
 
         @Test
         @DisplayName("Should resolve MockResponseConfig annotations on methods in nested classes")
-        void shouldResolveNestedClassMethodAnnotations() throws NoSuchMethodException {
+        void shouldResolveNestedClassMethodAnnotations() throws Exception {
             // Arrange
             Method testMethod = ClassWithNestedClassMethodTest.NestedTestClass.class.getDeclaredMethod("testMethod");
 

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -53,7 +52,7 @@ class MockResponseTest {
 
         @Test
         @DisplayName("Should return configured response with text content")
-        void shouldReturnConfiguredResponse(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldReturnConfiguredResponse(URIBuilder uriBuilder) throws Exception {
             // Arrange
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
@@ -85,7 +84,7 @@ class MockResponseTest {
 
         @Test
         @DisplayName("Should handle GET request with JSON content")
-        void shouldHandleGetRequest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldHandleGetRequest(URIBuilder uriBuilder) throws Exception {
             // Arrange
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
@@ -108,7 +107,7 @@ class MockResponseTest {
 
         @Test
         @DisplayName("Should handle POST request with 201 status code")
-        void shouldHandlePostRequest(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldHandlePostRequest(URIBuilder uriBuilder) throws Exception {
             // Arrange
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
@@ -140,7 +139,7 @@ class MockResponseTest {
 
         @Test
         @DisplayName("Should include custom headers in response")
-        void shouldIncludeCustomHeaders(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldIncludeCustomHeaders(URIBuilder uriBuilder) throws Exception {
             // Arrange
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)
@@ -175,7 +174,7 @@ class MockResponseTest {
 
             @Test
             @DisplayName("Should handle nested class annotations")
-            void shouldHandleNestedClassAnnotation(URIBuilder uriBuilder) throws IOException, InterruptedException {
+            void shouldHandleNestedClassAnnotation(URIBuilder uriBuilder) throws Exception {
                 // Arrange
                 HttpClient client = HttpClient.newBuilder()
                         .connectTimeout(TIMEOUT)
@@ -203,7 +202,7 @@ class MockResponseTest {
 
         @Test
         @MockResponseConfig(path = "/api/method", status = 200, textContent = "Method Response")
-        void shouldHandleMethodAnnotation(URIBuilder uriBuilder) throws IOException, InterruptedException {
+        void shouldHandleMethodAnnotation(URIBuilder uriBuilder) throws Exception {
             // Arrange
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(TIMEOUT)

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseTestUtil.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MockResponseTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MultipleAnnotationsTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/mockresponse/MultipleAnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.cuioss.test.mockwebserver.URIBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -45,7 +44,7 @@ class MultipleAnnotationsTest {
     @MockResponseConfig(path = "/api/method-1", status = 200, textContent = "Method 1 Response")
     @MockResponseConfig(path = "/api/method-2", status = 201, textContent = "Method 2 Response")
     @MockResponseConfig(path = "/api/method-3", status = 202, textContent = "Method 3 Response")
-    void shouldHandleMultipleAnnotations(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void shouldHandleMultipleAnnotations(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();
@@ -94,7 +93,7 @@ class MultipleAnnotationsTest {
     @Test
     @DisplayName("Should not have access to annotations from other methods")
     @MockResponseConfig(path = "/api/other-method", status = 200, textContent = "Other Method Response")
-    void shouldNotHaveAccessToOtherMethodAnnotations(URIBuilder uriBuilder) throws IOException, InterruptedException {
+    void shouldNotHaveAccessToOtherMethodAnnotations(URIBuilder uriBuilder) throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(TIMEOUT)
                 .build();

--- a/src/test/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtilTest.java
+++ b/src/test/java/de/cuioss/test/mockwebserver/ssl/KeyMaterialUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2025-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Why

`<inceptionYear>` is an **inherited** POM element, and the mycila `license-maven-plugin` binds the copyright `${year}` to `project.inceptionYear` — **not** to the current year:

```
ldc           "year"
getfield      project
invokevirtual MavenProject.getInceptionYear()
```

`cui-parent-pom` held the only declaration in the hierarchy (`2022`), so this project reported 2022 and **every `-Ppre-commit` run restamped every source header**. Declaring the real year stops that.

## The year

`2025` — from this repository's own first commit, not the parent and not GitHub's `created_at`.

## What is in this PR

Two things, and it is worth being precise about the second:

1. `pom.xml` gains `<inceptionYear>2025</inceptionYear>`, and the license plugin rewrites every source header to `© 2025-present`. **This is the change being made.**
2. **Pre-existing gate drift**, ~166 non-header lines. `-Ppre-commit` also runs OpenRewrite, which reorders imports, reformats, and adds build-plugin blocks. Confirmed pre-existing: running the gate on **unmodified `main`**, with no `inceptionYear` at all, produces the same kind of changes.

It cannot be split out. The gate re-applies it on the next run, so a header-only tree would not be gate-stable — and gate-stability is precisely the property this PR exists to restore.

## Verification

The gate was run **twice**. The second run rewrote nothing and left a tree identical to the first. That idempotence is what was broken, so it is the thing checked — not merely that the build passes.

Confirmed afterwards that every `.java` header in the tree reads `© 2025-present`, with no stragglers on other years.